### PR TITLE
WSFEX/WSFEcred services, docs, tests

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -71,6 +71,14 @@ export default withMermaid(
               link: "/facturacion_electronica",
             },
             {
+              text: "🌍 Facturación de exportación (WSFEX)",
+              link: "/facturacion_exportacion",
+            },
+            {
+              text: "💳 Factura de crédito electrónica (WSFEcred)",
+              link: "/facturacion_credito_electronica",
+            },
+            {
               text: "🔍 Consultas de padron",
               collapsed: true,
               items: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,16 @@ Explora la suite completa de herramientas diseñadas para potenciar tu negocio.
     <h3>Constancia de Inscripción</h3>
     <p>Obtén y verifica las constancias de inscripción de forma programática y segura.</p>
   </a>
+  <a href="/services/facturacion_exportacion" class="service-card">
+    <div class="card-icon">🌍</div>
+    <h3>Facturación de Exportación</h3>
+    <p>Emisión y consulta de comprobantes de exportación con WSFEX.</p>
+  </a>
+  <a href="/services/facturacion_credito_electronica" class="service-card">
+    <div class="card-icon">💳</div>
+    <h3>Factura de Crédito Electrónica</h3>
+    <p>Gestión de facturas MiPyMEs, cuentas corrientes y cancelaciones con WSFEcred.</p>
+  </a>
 </div>
 
 ## 📚 Centro de Conocimiento

--- a/docs/services/facturacion_credito_electronica.md
+++ b/docs/services/facturacion_credito_electronica.md
@@ -1,0 +1,145 @@
+# 💳 Factura de Crédito Electrónica (WSFEcred)
+
+El servicio `wsfecredService` permite gestionar Facturas de Crédito Electrónicas MiPyMEs mediante el Web Service de Factura de Crédito Electrónica (WSFEcred).
+
+[[toc]]
+
+## Aceptar factura
+
+```ts
+const result = await arca.wsfecredService.aceptarFECred({
+  rolCUITRepresentada: "COMPRADOR",
+  idCtaCte: 123456789,
+  tipoCancelacion: "PAR",
+  importeCancelado: 1000,
+});
+```
+
+## Rechazar factura
+
+```ts
+const result = await arca.wsfecredService.rechazarFECred({
+  rolCUITRepresentada: "COMPRADOR",
+  idCtaCte: 123456789,
+  codMotivoRechazo: 12,
+  descMotivoRechazo: "Diferencia en condiciones",
+});
+```
+
+## Rechazar nota de débito/crédito
+
+```ts
+const result = await arca.wsfecredService.rechazarNotaDC({
+  rolCUITRepresentada: "COMPRADOR",
+  idComprobante: 987654321,
+  codMotivoRechazo: 5,
+});
+```
+
+## Informar factura a agente de depósito colectivo
+
+```ts
+const result = await arca.wsfecredService.informarFacturaAgtDptoCltv({
+  rolCUITRepresentada: "VENDEDOR",
+  idCtaCte: 123456789,
+  codAgtDptoCltv: "BCBA",
+});
+```
+
+## Informar cancelación total
+
+```ts
+const result = await arca.wsfecredService.informarCancelacionTotalFECred({
+  rolCUITRepresentada: "COMPRADOR",
+  idCtaCte: 123456789,
+  importeCancelacion: 1500,
+});
+```
+
+## Modificar opción de transferencia
+
+```ts
+const result = await arca.wsfecredService.modificarOpcionTransferencia({
+  rolCUITRepresentada: "VENDEDOR",
+  idCtaCte: 123456789,
+  opcionTransferencia: "ADC",
+});
+```
+
+## Consultas
+
+La consulta de obligación de recepción por monto reemplaza a la operación
+`consultarObligadoRecepcion`, que está deprecada por AFIP.
+
+::: code-group
+
+```ts [Comprobantes]
+const data = await arca.wsfecredService.consultarComprobantes({
+  rolCUITRepresentada: "COMPRADOR",
+  nroPagina: 1,
+});
+```
+
+```ts [Cuenta Corriente]
+const cta = await arca.wsfecredService.consultarCtaCte({
+  rolCUITRepresentada: "COMPRADOR",
+  idCtaCte: 123456789,
+});
+```
+
+```ts [Cuentas Corrientes]
+const ctas = await arca.wsfecredService.consultarCtasCtes({
+  rolCUITRepresentada: "COMPRADOR",
+  nroPagina: 1,
+});
+```
+
+```ts [Historial de estados]
+const history = await arca.wsfecredService.consultarHistorialEstadosComprobante({
+  rolCUITRepresentada: "COMPRADOR",
+  idComprobante: 987654321,
+});
+```
+
+```ts [Obligación de recepción por monto]
+const obligado = await arca.wsfecredService.consultarMontoObligadoRecepcion({
+  rolCUITRepresentada: "COMPRADOR",
+  cuitConsultada: 20210861220,
+  importeComprobante: 1000,
+  fechaEmision: "2024-01-01",
+});
+```
+
+```ts [Tipos de motivos de rechazo]
+const reasons = await arca.wsfecredService.consultarTiposMotivosRechazo({
+  rolCUITRepresentada: "COMPRADOR",
+});
+```
+
+```ts [Tipos de formas de cancelación]
+const cancelTypes = await arca.wsfecredService.consultarTiposFormasCancelacion({
+  rolCUITRepresentada: "COMPRADOR",
+});
+```
+
+```ts [Tipos de retenciones]
+const retenciones = await arca.wsfecredService.consultarTiposRetenciones({
+  rolCUITRepresentada: "COMPRADOR",
+});
+```
+
+```ts [Remitos asociados]
+const remitos = await arca.wsfecredService.obtenerRemitos({
+  rolCUITRepresentada: "COMPRADOR",
+  idComprobante: 987654321,
+});
+```
+
+:::
+
+## Estado del servidor
+
+```ts
+const status = await arca.wsfecredService.getServerStatus();
+console.log(status);
+```

--- a/docs/services/facturacion_exportacion.md
+++ b/docs/services/facturacion_exportacion.md
@@ -1,0 +1,91 @@
+# 🌍 Facturación de Exportación (WSFEX)
+
+El servicio `wsfexService` permite emitir y consultar comprobantes de exportación mediante el Web Service de Facturación de Exportación (WSFEX).
+
+[[toc]]
+
+## Autorizar comprobante
+
+```ts
+const result = await arca.wsfexService.authorize({
+  Cbte_tipo: 19,
+  Punto_vta: 1,
+  Cbte_nro: 1,
+  Fecha_cbte: "20240123",
+  Tipo_expo: 1,
+  Permiso_existente: "N",
+  Dst_cmp: 212,
+  Cliente: "Cliente del exterior",
+  Cuit_pais_cliente: 1234567890123,
+  Domicilio_cliente: "Calle 123",
+  Moneda_Id: "USD",
+  Moneda_ctz: 900.5,
+  Imp_total: 1000,
+  Idioma_cbte: 1,
+});
+```
+
+## Consultar comprobante
+
+```ts
+const cmp = await arca.wsfexService.getCmp({
+  Cbte_tipo: 19,
+  Punto_vta: 1,
+  Cbte_nro: 1,
+});
+```
+
+## Último comprobante autorizado
+
+```ts
+const last = await arca.wsfexService.getLastCmp({
+  Pto_venta: 1,
+  Cbte_Tipo: 19,
+});
+```
+
+## Tablas de referencia
+
+::: code-group
+
+```ts [Puntos de Venta]
+const points = await arca.wsfexService.getParamPtoVenta();
+```
+
+```ts [Tipos de Comprobante]
+const types = await arca.wsfexService.getParamCbteTipo();
+```
+
+```ts [Tipos de Exportación]
+const exportTypes = await arca.wsfexService.getParamTipoExpo();
+```
+
+```ts [Incoterms]
+const incoterms = await arca.wsfexService.getParamIncoterms();
+```
+
+```ts [Monedas]
+const currencies = await arca.wsfexService.getParamMon();
+```
+
+```ts [Cotización por Moneda]
+const quote = await arca.wsfexService.getParamCtz({
+  Mon_id: "USD",
+  FchCotiz: "20240123",
+});
+```
+
+```ts [Monedas con Cotización]
+const withQuote = await arca.wsfexService.getParamMonCotizacion({
+  Fecha_CTZ: "20240123",
+});
+```
+
+:::
+
+## Estado del servidor
+
+```ts
+const status = await arca.wsfexService.getServerStatus();
+console.log(status);
+```

--- a/packages/core/src/application/dto/fecred.dto.ts
+++ b/packages/core/src/application/dto/fecred.dto.ts
@@ -1,0 +1,72 @@
+/**
+ * WSFEcred DTOs
+ * Data transfer objects for Factura de Crédito Electrónica
+ */
+export interface FecredServerStatusDto {
+  appserver: string;
+  dbserver: string;
+  authserver: string;
+}
+
+export type FecredAcceptRequestDto = Record<string, any>;
+export type FecredAcceptResultDto = Record<string, any>;
+
+export type FecredRejectRequestDto = Record<string, any>;
+export type FecredRejectResultDto = Record<string, any>;
+
+export type FecredRejectNoteRequestDto = Record<string, any>;
+export type FecredRejectNoteResultDto = Record<string, any>;
+
+export type FecredInformFacturaAgtDptoCltvRequestDto = Record<string, any>;
+export type FecredInformFacturaAgtDptoCltvResultDto = Record<string, any>;
+
+export type FecredInformCancelacionTotalRequestDto = Record<string, any>;
+export type FecredInformCancelacionTotalResultDto = Record<string, any>;
+
+export type FecredModifyTransferOptionRequestDto = Record<string, any>;
+export type FecredModifyTransferOptionResultDto = Record<string, any>;
+
+export type FecredConsultarComprobantesRequestDto = Record<string, any>;
+export type FecredConsultarComprobantesResultDto = Record<string, any>;
+
+export type FecredConsultarCtaCteRequestDto = Record<string, any>;
+export type FecredConsultarCtaCteResultDto = Record<string, any>;
+
+export type FecredConsultarCtasCtesRequestDto = Record<string, any>;
+export type FecredConsultarCtasCtesResultDto = Record<string, any>;
+
+export type FecredConsultarCuentasEnAgtDptoCltvRequestDto = Record<string, any>;
+export type FecredConsultarCuentasEnAgtDptoCltvResultDto = Record<string, any>;
+
+export type FecredConsultarFacturasAgtDptoCltvRequestDto = Record<string, any>;
+export type FecredConsultarFacturasAgtDptoCltvResultDto = Record<string, any>;
+
+export type FecredConsultarHistorialEstadosComprobanteRequestDto =
+  Record<string, any>;
+export type FecredConsultarHistorialEstadosComprobanteResultDto =
+  Record<string, any>;
+
+export type FecredConsultarHistorialEstadosCtaCteRequestDto = Record<string, any>;
+export type FecredConsultarHistorialEstadosCtaCteResultDto =
+  Record<string, any>;
+
+export type FecredConsultarMontoObligadoRecepcionRequestDto = Record<string, any>;
+export type FecredConsultarMontoObligadoRecepcionResultDto = Record<string, any>;
+
+export type FecredConsultarObligadoRecepcionRequestDto = Record<string, any>;
+export type FecredConsultarObligadoRecepcionResultDto = Record<string, any>;
+
+export type FecredConsultarTiposAjustesOperacionRequestDto = Record<string, any>;
+export type FecredConsultarTiposAjustesOperacionResultDto = Record<string, any>;
+
+export type FecredConsultarTiposFormasCancelacionRequestDto = Record<string, any>;
+export type FecredConsultarTiposFormasCancelacionResultDto = Record<string, any>;
+
+export type FecredConsultarTiposMotivosRechazoRequestDto = Record<string, any>;
+export type FecredConsultarTiposMotivosRechazoResultDto = Record<string, any>;
+
+export type FecredConsultarTiposRetencionesRequestDto = Record<string, any>;
+export type FecredConsultarTiposRetencionesResultDto = Record<string, any>;
+
+export type FecredObtenerRemitosRequestDto = Record<string, any>;
+export type FecredObtenerRemitosResultDto = Record<string, any>;

--- a/packages/core/src/application/dto/fex.dto.ts
+++ b/packages/core/src/application/dto/fex.dto.ts
@@ -1,0 +1,59 @@
+/**
+ * WSFEX DTOs
+ * Minimal typing for Export Electronic Billing service
+ */
+export interface FexServerStatusDto {
+  appserver: string;
+  dbserver: string;
+  authserver: string;
+}
+
+export type FexAuthorizeRequestDto = Record<string, any>;
+export type FexAuthorizeResultDto = Record<string, any>;
+
+export interface FexGetCmpRequestDto {
+  Cbte_tipo: number;
+  Punto_vta: number;
+  Cbte_nro: number;
+}
+
+export type FexGetCmpResultDto = Record<string, any>;
+
+export interface FexGetLastCmpRequestDto {
+  Pto_venta: number;
+  Cbte_Tipo: number;
+}
+
+export type FexGetLastCmpResultDto = Record<string, any>;
+
+export type FexGetLastIdResultDto = Record<string, any>;
+
+export interface FexCheckPermisoRequestDto {
+  ID_Permiso?: string;
+  Dst_merc: number;
+}
+
+export type FexCheckPermisoResultDto = Record<string, any>;
+
+export interface FexGetParamCtzRequestDto {
+  Mon_id?: string;
+  FchCotiz?: string;
+}
+
+export type FexParamCtzResultDto = Record<string, any>;
+export type FexParamMonCotizacionResultDto = Record<string, any>;
+export type FexParamMonResultDto = Record<string, any>;
+export type FexParamPtoVentaResultDto = Record<string, any>;
+export type FexParamCbteTipoResultDto = Record<string, any>;
+export type FexParamTipoExpoResultDto = Record<string, any>;
+export type FexParamIncotermsResultDto = Record<string, any>;
+export type FexParamIdiomasResultDto = Record<string, any>;
+export type FexParamUmedResultDto = Record<string, any>;
+export type FexParamDstPaisResultDto = Record<string, any>;
+export type FexParamDstCuitResultDto = Record<string, any>;
+export type FexParamOpcionalesResultDto = Record<string, any>;
+export type FexParamActividadesResultDto = Record<string, any>;
+
+export interface FexParamMonCotizacionRequestDto {
+  Fecha_CTZ?: string;
+}

--- a/packages/core/src/application/dto/index.ts
+++ b/packages/core/src/application/dto/index.ts
@@ -3,4 +3,6 @@
  * Exports all DTOs for use case inputs and outputs
  */
 export * from "./electronic-billing.dto";
+export * from "./fecred.dto";
+export * from "./fex.dto";
 export * from "./register.dto";

--- a/packages/core/src/application/ports/fecred/fecred-repository.port.ts
+++ b/packages/core/src/application/ports/fecred/fecred-repository.port.ts
@@ -1,0 +1,107 @@
+/**
+ * WSFEcred Repository Port
+ * Port defined by the application layer for Factura de Crédito Electrónica
+ */
+import {
+  FecredAcceptRequestDto,
+  FecredAcceptResultDto,
+  FecredConsultarComprobantesRequestDto,
+  FecredConsultarComprobantesResultDto,
+  FecredConsultarCtaCteRequestDto,
+  FecredConsultarCtaCteResultDto,
+  FecredConsultarCtasCtesRequestDto,
+  FecredConsultarCtasCtesResultDto,
+  FecredConsultarCuentasEnAgtDptoCltvRequestDto,
+  FecredConsultarCuentasEnAgtDptoCltvResultDto,
+  FecredConsultarFacturasAgtDptoCltvRequestDto,
+  FecredConsultarFacturasAgtDptoCltvResultDto,
+  FecredConsultarHistorialEstadosComprobanteRequestDto,
+  FecredConsultarHistorialEstadosComprobanteResultDto,
+  FecredConsultarHistorialEstadosCtaCteRequestDto,
+  FecredConsultarHistorialEstadosCtaCteResultDto,
+  FecredConsultarMontoObligadoRecepcionRequestDto,
+  FecredConsultarMontoObligadoRecepcionResultDto,
+  FecredConsultarObligadoRecepcionRequestDto,
+  FecredConsultarObligadoRecepcionResultDto,
+  FecredConsultarTiposAjustesOperacionRequestDto,
+  FecredConsultarTiposAjustesOperacionResultDto,
+  FecredConsultarTiposFormasCancelacionRequestDto,
+  FecredConsultarTiposFormasCancelacionResultDto,
+  FecredConsultarTiposMotivosRechazoRequestDto,
+  FecredConsultarTiposMotivosRechazoResultDto,
+  FecredConsultarTiposRetencionesRequestDto,
+  FecredConsultarTiposRetencionesResultDto,
+  FecredInformCancelacionTotalRequestDto,
+  FecredInformCancelacionTotalResultDto,
+  FecredInformFacturaAgtDptoCltvRequestDto,
+  FecredInformFacturaAgtDptoCltvResultDto,
+  FecredModifyTransferOptionRequestDto,
+  FecredModifyTransferOptionResultDto,
+  FecredObtenerRemitosRequestDto,
+  FecredObtenerRemitosResultDto,
+  FecredRejectNoteRequestDto,
+  FecredRejectNoteResultDto,
+  FecredRejectRequestDto,
+  FecredRejectResultDto,
+  FecredServerStatusDto,
+} from "@application/dto/fecred.dto";
+
+export interface IWsfecredRepositoryPort {
+  getServerStatus(): Promise<FecredServerStatusDto>;
+  aceptarFECred(params: FecredAcceptRequestDto): Promise<FecredAcceptResultDto>;
+  rechazarFECred(params: FecredRejectRequestDto): Promise<FecredRejectResultDto>;
+  rechazarNotaDC(
+    params: FecredRejectNoteRequestDto
+  ): Promise<FecredRejectNoteResultDto>;
+  informarFacturaAgtDptoCltv(
+    params: FecredInformFacturaAgtDptoCltvRequestDto
+  ): Promise<FecredInformFacturaAgtDptoCltvResultDto>;
+  informarCancelacionTotalFECred(
+    params: FecredInformCancelacionTotalRequestDto
+  ): Promise<FecredInformCancelacionTotalResultDto>;
+  modificarOpcionTransferencia(
+    params: FecredModifyTransferOptionRequestDto
+  ): Promise<FecredModifyTransferOptionResultDto>;
+  consultarComprobantes(
+    params: FecredConsultarComprobantesRequestDto
+  ): Promise<FecredConsultarComprobantesResultDto>;
+  consultarCtaCte(
+    params: FecredConsultarCtaCteRequestDto
+  ): Promise<FecredConsultarCtaCteResultDto>;
+  consultarCtasCtes(
+    params: FecredConsultarCtasCtesRequestDto
+  ): Promise<FecredConsultarCtasCtesResultDto>;
+  consultarCuentasEnAgtDptoCltv(
+    params: FecredConsultarCuentasEnAgtDptoCltvRequestDto
+  ): Promise<FecredConsultarCuentasEnAgtDptoCltvResultDto>;
+  consultarFacturasAgtDptoCltv(
+    params: FecredConsultarFacturasAgtDptoCltvRequestDto
+  ): Promise<FecredConsultarFacturasAgtDptoCltvResultDto>;
+  consultarHistorialEstadosComprobante(
+    params: FecredConsultarHistorialEstadosComprobanteRequestDto
+  ): Promise<FecredConsultarHistorialEstadosComprobanteResultDto>;
+  consultarHistorialEstadosCtaCte(
+    params: FecredConsultarHistorialEstadosCtaCteRequestDto
+  ): Promise<FecredConsultarHistorialEstadosCtaCteResultDto>;
+  consultarMontoObligadoRecepcion(
+    params: FecredConsultarMontoObligadoRecepcionRequestDto
+  ): Promise<FecredConsultarMontoObligadoRecepcionResultDto>;
+  consultarObligadoRecepcion(
+    params: FecredConsultarObligadoRecepcionRequestDto
+  ): Promise<FecredConsultarObligadoRecepcionResultDto>;
+  consultarTiposAjustesOperacion(
+    params: FecredConsultarTiposAjustesOperacionRequestDto
+  ): Promise<FecredConsultarTiposAjustesOperacionResultDto>;
+  consultarTiposFormasCancelacion(
+    params: FecredConsultarTiposFormasCancelacionRequestDto
+  ): Promise<FecredConsultarTiposFormasCancelacionResultDto>;
+  consultarTiposMotivosRechazo(
+    params: FecredConsultarTiposMotivosRechazoRequestDto
+  ): Promise<FecredConsultarTiposMotivosRechazoResultDto>;
+  consultarTiposRetenciones(
+    params: FecredConsultarTiposRetencionesRequestDto
+  ): Promise<FecredConsultarTiposRetencionesResultDto>;
+  obtenerRemitos(
+    params: FecredObtenerRemitosRequestDto
+  ): Promise<FecredObtenerRemitosResultDto>;
+}

--- a/packages/core/src/application/ports/fecred/index.ts
+++ b/packages/core/src/application/ports/fecred/index.ts
@@ -1,0 +1,4 @@
+/**
+ * WSFEcred Ports
+ */
+export * from "./fecred-repository.port";

--- a/packages/core/src/application/ports/fex/fex-repository.port.ts
+++ b/packages/core/src/application/ports/fex/fex-repository.port.ts
@@ -1,0 +1,57 @@
+/**
+ * WSFEX Repository Port
+ * Port defined by the application layer for Export Electronic Billing
+ */
+import {
+  FexAuthorizeRequestDto,
+  FexAuthorizeResultDto,
+  FexCheckPermisoRequestDto,
+  FexCheckPermisoResultDto,
+  FexGetCmpRequestDto,
+  FexGetCmpResultDto,
+  FexGetLastCmpRequestDto,
+  FexGetLastCmpResultDto,
+  FexGetLastIdResultDto,
+  FexGetParamCtzRequestDto,
+  FexParamActividadesResultDto,
+  FexParamCbteTipoResultDto,
+  FexParamCtzResultDto,
+  FexParamDstCuitResultDto,
+  FexParamDstPaisResultDto,
+  FexParamIdiomasResultDto,
+  FexParamIncotermsResultDto,
+  FexParamMonCotizacionRequestDto,
+  FexParamMonCotizacionResultDto,
+  FexParamMonResultDto,
+  FexParamOpcionalesResultDto,
+  FexParamPtoVentaResultDto,
+  FexParamTipoExpoResultDto,
+  FexParamUmedResultDto,
+  FexServerStatusDto,
+} from "@application/dto/fex.dto";
+
+export interface IWsfexRepositoryPort {
+  getServerStatus(): Promise<FexServerStatusDto>;
+  authorize(cmp: FexAuthorizeRequestDto): Promise<FexAuthorizeResultDto>;
+  getCmp(params: FexGetCmpRequestDto): Promise<FexGetCmpResultDto>;
+  getLastCmp(params: FexGetLastCmpRequestDto): Promise<FexGetLastCmpResultDto>;
+  getLastId(): Promise<FexGetLastIdResultDto>;
+  checkPermiso(
+    params: FexCheckPermisoRequestDto
+  ): Promise<FexCheckPermisoResultDto>;
+  getParamPtoVenta(): Promise<FexParamPtoVentaResultDto>;
+  getParamCbteTipo(): Promise<FexParamCbteTipoResultDto>;
+  getParamTipoExpo(): Promise<FexParamTipoExpoResultDto>;
+  getParamIncoterms(): Promise<FexParamIncotermsResultDto>;
+  getParamIdiomas(): Promise<FexParamIdiomasResultDto>;
+  getParamUmed(): Promise<FexParamUmedResultDto>;
+  getParamDstPais(): Promise<FexParamDstPaisResultDto>;
+  getParamDstCuit(): Promise<FexParamDstCuitResultDto>;
+  getParamMon(): Promise<FexParamMonResultDto>;
+  getParamMonCotizacion(
+    params?: FexParamMonCotizacionRequestDto
+  ): Promise<FexParamMonCotizacionResultDto>;
+  getParamCtz(params?: FexGetParamCtzRequestDto): Promise<FexParamCtzResultDto>;
+  getParamOpcionales(): Promise<FexParamOpcionalesResultDto>;
+  getParamActividades(): Promise<FexParamActividadesResultDto>;
+}

--- a/packages/core/src/application/ports/fex/index.ts
+++ b/packages/core/src/application/ports/fex/index.ts
@@ -1,0 +1,1 @@
+export * from "./fex-repository.port";

--- a/packages/core/src/application/ports/index.ts
+++ b/packages/core/src/application/ports/index.ts
@@ -4,5 +4,7 @@
  */
 export * from "./authentication";
 export * from "./electronic-billing";
+export * from "./fecred";
+export * from "./fex";
 export * from "./register";
 

--- a/packages/core/src/application/services/index.ts
+++ b/packages/core/src/application/services/index.ts
@@ -3,6 +3,8 @@
  * Exports all application services that orchestrate use cases
  */
 export * from "./electronic-billing.service";
+export * from "./wsfecred.service";
+export * from "./wsfex.service";
 export * from "./register-scope-four.service";
 export * from "./register-scope-five.service";
 export * from "./register-scope-ten.service";

--- a/packages/core/src/application/services/wsfecred.service.ts
+++ b/packages/core/src/application/services/wsfecred.service.ts
@@ -1,0 +1,176 @@
+/**
+ * WSFEcred Service
+ * Application service for Factura de Crédito Electrónica
+ */
+import {
+  FecredAcceptRequestDto,
+  FecredAcceptResultDto,
+  FecredConsultarComprobantesRequestDto,
+  FecredConsultarComprobantesResultDto,
+  FecredConsultarCtaCteRequestDto,
+  FecredConsultarCtaCteResultDto,
+  FecredConsultarCtasCtesRequestDto,
+  FecredConsultarCtasCtesResultDto,
+  FecredConsultarCuentasEnAgtDptoCltvRequestDto,
+  FecredConsultarCuentasEnAgtDptoCltvResultDto,
+  FecredConsultarFacturasAgtDptoCltvRequestDto,
+  FecredConsultarFacturasAgtDptoCltvResultDto,
+  FecredConsultarHistorialEstadosComprobanteRequestDto,
+  FecredConsultarHistorialEstadosComprobanteResultDto,
+  FecredConsultarHistorialEstadosCtaCteRequestDto,
+  FecredConsultarHistorialEstadosCtaCteResultDto,
+  FecredConsultarMontoObligadoRecepcionRequestDto,
+  FecredConsultarMontoObligadoRecepcionResultDto,
+  FecredConsultarObligadoRecepcionRequestDto,
+  FecredConsultarObligadoRecepcionResultDto,
+  FecredConsultarTiposAjustesOperacionRequestDto,
+  FecredConsultarTiposAjustesOperacionResultDto,
+  FecredConsultarTiposFormasCancelacionRequestDto,
+  FecredConsultarTiposFormasCancelacionResultDto,
+  FecredConsultarTiposMotivosRechazoRequestDto,
+  FecredConsultarTiposMotivosRechazoResultDto,
+  FecredConsultarTiposRetencionesRequestDto,
+  FecredConsultarTiposRetencionesResultDto,
+  FecredInformCancelacionTotalRequestDto,
+  FecredInformCancelacionTotalResultDto,
+  FecredInformFacturaAgtDptoCltvRequestDto,
+  FecredInformFacturaAgtDptoCltvResultDto,
+  FecredModifyTransferOptionRequestDto,
+  FecredModifyTransferOptionResultDto,
+  FecredObtenerRemitosRequestDto,
+  FecredObtenerRemitosResultDto,
+  FecredRejectNoteRequestDto,
+  FecredRejectNoteResultDto,
+  FecredRejectRequestDto,
+  FecredRejectResultDto,
+  FecredServerStatusDto,
+} from "@application/dto/fecred.dto";
+import { IWsfecredRepositoryPort } from "@application/ports/fecred/fecred-repository.port";
+
+export class WsfecredService {
+  constructor(private readonly repository: IWsfecredRepositoryPort) {}
+
+  async getServerStatus(): Promise<FecredServerStatusDto> {
+    return this.repository.getServerStatus();
+  }
+
+  async aceptarFECred(
+    params: FecredAcceptRequestDto
+  ): Promise<FecredAcceptResultDto> {
+    return this.repository.aceptarFECred(params);
+  }
+
+  async rechazarFECred(
+    params: FecredRejectRequestDto
+  ): Promise<FecredRejectResultDto> {
+    return this.repository.rechazarFECred(params);
+  }
+
+  async rechazarNotaDC(
+    params: FecredRejectNoteRequestDto
+  ): Promise<FecredRejectNoteResultDto> {
+    return this.repository.rechazarNotaDC(params);
+  }
+
+  async informarFacturaAgtDptoCltv(
+    params: FecredInformFacturaAgtDptoCltvRequestDto
+  ): Promise<FecredInformFacturaAgtDptoCltvResultDto> {
+    return this.repository.informarFacturaAgtDptoCltv(params);
+  }
+
+  async informarCancelacionTotalFECred(
+    params: FecredInformCancelacionTotalRequestDto
+  ): Promise<FecredInformCancelacionTotalResultDto> {
+    return this.repository.informarCancelacionTotalFECred(params);
+  }
+
+  async modificarOpcionTransferencia(
+    params: FecredModifyTransferOptionRequestDto
+  ): Promise<FecredModifyTransferOptionResultDto> {
+    return this.repository.modificarOpcionTransferencia(params);
+  }
+
+  async consultarComprobantes(
+    params: FecredConsultarComprobantesRequestDto
+  ): Promise<FecredConsultarComprobantesResultDto> {
+    return this.repository.consultarComprobantes(params);
+  }
+
+  async consultarCtaCte(
+    params: FecredConsultarCtaCteRequestDto
+  ): Promise<FecredConsultarCtaCteResultDto> {
+    return this.repository.consultarCtaCte(params);
+  }
+
+  async consultarCtasCtes(
+    params: FecredConsultarCtasCtesRequestDto
+  ): Promise<FecredConsultarCtasCtesResultDto> {
+    return this.repository.consultarCtasCtes(params);
+  }
+
+  async consultarCuentasEnAgtDptoCltv(
+    params: FecredConsultarCuentasEnAgtDptoCltvRequestDto
+  ): Promise<FecredConsultarCuentasEnAgtDptoCltvResultDto> {
+    return this.repository.consultarCuentasEnAgtDptoCltv(params);
+  }
+
+  async consultarFacturasAgtDptoCltv(
+    params: FecredConsultarFacturasAgtDptoCltvRequestDto
+  ): Promise<FecredConsultarFacturasAgtDptoCltvResultDto> {
+    return this.repository.consultarFacturasAgtDptoCltv(params);
+  }
+
+  async consultarHistorialEstadosComprobante(
+    params: FecredConsultarHistorialEstadosComprobanteRequestDto
+  ): Promise<FecredConsultarHistorialEstadosComprobanteResultDto> {
+    return this.repository.consultarHistorialEstadosComprobante(params);
+  }
+
+  async consultarHistorialEstadosCtaCte(
+    params: FecredConsultarHistorialEstadosCtaCteRequestDto
+  ): Promise<FecredConsultarHistorialEstadosCtaCteResultDto> {
+    return this.repository.consultarHistorialEstadosCtaCte(params);
+  }
+
+  async consultarMontoObligadoRecepcion(
+    params: FecredConsultarMontoObligadoRecepcionRequestDto
+  ): Promise<FecredConsultarMontoObligadoRecepcionResultDto> {
+    return this.repository.consultarMontoObligadoRecepcion(params);
+  }
+
+  async consultarObligadoRecepcion(
+    params: FecredConsultarObligadoRecepcionRequestDto
+  ): Promise<FecredConsultarObligadoRecepcionResultDto> {
+    return this.repository.consultarMontoObligadoRecepcion(params);
+  }
+
+  async consultarTiposAjustesOperacion(
+    params: FecredConsultarTiposAjustesOperacionRequestDto
+  ): Promise<FecredConsultarTiposAjustesOperacionResultDto> {
+    return this.repository.consultarTiposAjustesOperacion(params);
+  }
+
+  async consultarTiposFormasCancelacion(
+    params: FecredConsultarTiposFormasCancelacionRequestDto
+  ): Promise<FecredConsultarTiposFormasCancelacionResultDto> {
+    return this.repository.consultarTiposFormasCancelacion(params);
+  }
+
+  async consultarTiposMotivosRechazo(
+    params: FecredConsultarTiposMotivosRechazoRequestDto
+  ): Promise<FecredConsultarTiposMotivosRechazoResultDto> {
+    return this.repository.consultarTiposMotivosRechazo(params);
+  }
+
+  async consultarTiposRetenciones(
+    params: FecredConsultarTiposRetencionesRequestDto
+  ): Promise<FecredConsultarTiposRetencionesResultDto> {
+    return this.repository.consultarTiposRetenciones(params);
+  }
+
+  async obtenerRemitos(
+    params: FecredObtenerRemitosRequestDto
+  ): Promise<FecredObtenerRemitosResultDto> {
+    return this.repository.obtenerRemitos(params);
+  }
+}

--- a/packages/core/src/application/services/wsfex.service.ts
+++ b/packages/core/src/application/services/wsfex.service.ts
@@ -1,0 +1,120 @@
+/**
+ * WSFEX Service
+ * Application service for Export Electronic Billing
+ */
+import {
+  FexAuthorizeRequestDto,
+  FexAuthorizeResultDto,
+  FexCheckPermisoRequestDto,
+  FexCheckPermisoResultDto,
+  FexGetCmpRequestDto,
+  FexGetCmpResultDto,
+  FexGetLastCmpRequestDto,
+  FexGetLastCmpResultDto,
+  FexGetLastIdResultDto,
+  FexGetParamCtzRequestDto,
+  FexParamActividadesResultDto,
+  FexParamCbteTipoResultDto,
+  FexParamCtzResultDto,
+  FexParamDstCuitResultDto,
+  FexParamDstPaisResultDto,
+  FexParamIdiomasResultDto,
+  FexParamIncotermsResultDto,
+  FexParamMonCotizacionRequestDto,
+  FexParamMonCotizacionResultDto,
+  FexParamMonResultDto,
+  FexParamOpcionalesResultDto,
+  FexParamPtoVentaResultDto,
+  FexParamTipoExpoResultDto,
+  FexParamUmedResultDto,
+  FexServerStatusDto,
+} from "@application/dto/fex.dto";
+import { IWsfexRepositoryPort } from "@application/ports/fex/fex-repository.port";
+
+export class WsfexService {
+  constructor(private readonly repository: IWsfexRepositoryPort) {}
+
+  async getServerStatus(): Promise<FexServerStatusDto> {
+    return this.repository.getServerStatus();
+  }
+
+  async authorize(cmp: FexAuthorizeRequestDto): Promise<FexAuthorizeResultDto> {
+    return this.repository.authorize(cmp);
+  }
+
+  async getCmp(params: FexGetCmpRequestDto): Promise<FexGetCmpResultDto> {
+    return this.repository.getCmp(params);
+  }
+
+  async getLastCmp(
+    params: FexGetLastCmpRequestDto
+  ): Promise<FexGetLastCmpResultDto> {
+    return this.repository.getLastCmp(params);
+  }
+
+  async getLastId(): Promise<FexGetLastIdResultDto> {
+    return this.repository.getLastId();
+  }
+
+  async checkPermiso(
+    params: FexCheckPermisoRequestDto
+  ): Promise<FexCheckPermisoResultDto> {
+    return this.repository.checkPermiso(params);
+  }
+
+  async getParamPtoVenta(): Promise<FexParamPtoVentaResultDto> {
+    return this.repository.getParamPtoVenta();
+  }
+
+  async getParamCbteTipo(): Promise<FexParamCbteTipoResultDto> {
+    return this.repository.getParamCbteTipo();
+  }
+
+  async getParamTipoExpo(): Promise<FexParamTipoExpoResultDto> {
+    return this.repository.getParamTipoExpo();
+  }
+
+  async getParamIncoterms(): Promise<FexParamIncotermsResultDto> {
+    return this.repository.getParamIncoterms();
+  }
+
+  async getParamIdiomas(): Promise<FexParamIdiomasResultDto> {
+    return this.repository.getParamIdiomas();
+  }
+
+  async getParamUmed(): Promise<FexParamUmedResultDto> {
+    return this.repository.getParamUmed();
+  }
+
+  async getParamDstPais(): Promise<FexParamDstPaisResultDto> {
+    return this.repository.getParamDstPais();
+  }
+
+  async getParamDstCuit(): Promise<FexParamDstCuitResultDto> {
+    return this.repository.getParamDstCuit();
+  }
+
+  async getParamMon(): Promise<FexParamMonResultDto> {
+    return this.repository.getParamMon();
+  }
+
+  async getParamMonCotizacion(
+    params?: FexParamMonCotizacionRequestDto
+  ): Promise<FexParamMonCotizacionResultDto> {
+    return this.repository.getParamMonCotizacion(params);
+  }
+
+  async getParamCtz(
+    params?: FexGetParamCtzRequestDto
+  ): Promise<FexParamCtzResultDto> {
+    return this.repository.getParamCtz(params);
+  }
+
+  async getParamOpcionales(): Promise<FexParamOpcionalesResultDto> {
+    return this.repository.getParamOpcionales();
+  }
+
+  async getParamActividades(): Promise<FexParamActividadesResultDto> {
+    return this.repository.getParamActividades();
+  }
+}

--- a/packages/core/src/infrastructure/inbound/adapters/arca.ts
+++ b/packages/core/src/infrastructure/inbound/adapters/arca.ts
@@ -12,12 +12,16 @@ import { IAuthenticationRepositoryPort } from "@application/ports/authentication
 import { IElectronicBillingRepositoryPort } from "@application/ports/electronic-billing/electronic-billing-repository.port";
 
 import { ElectronicBillingService } from "@application/services/electronic-billing.service";
+import { WsfecredService } from "@application/services/wsfecred.service";
+import { WsfexService } from "@application/services/wsfex.service";
 import { RegisterScopeFourService } from "@application/services/register-scope-four.service";
 import { RegisterScopeFiveService } from "@application/services/register-scope-five.service";
 import { RegisterScopeTenService } from "@application/services/register-scope-ten.service";
 import { RegisterScopeThirteenService } from "@application/services/register-scope-thirteen.service";
 import { RegisterInscriptionProofService } from "@application/services/register-inscription-proof.service";
 import { ElectronicBillingRepository } from "@infrastructure/outbound/adapters/electronic-billing/electronic-billing-repository";
+import { WsfecredRepository } from "@infrastructure/outbound/adapters/fecred/fecred-repository";
+import { WsfexRepository } from "@infrastructure/outbound/adapters/fex/fex-repository";
 import { RegisterScopeFourRepository } from "@infrastructure/outbound/adapters/register/register-scope-four.repository";
 import { RegisterScopeFiveRepository } from "@infrastructure/outbound/adapters/register/register-scope-five.repository";
 import { RegisterScopeTenRepository } from "@infrastructure/outbound/adapters/register/register-scope-ten.repository";
@@ -30,6 +34,8 @@ import { DEFAULT_USE_HTTPS_AGENT } from "@infrastructure/constants";
 
 export class Arca {
   private readonly _electronicBillingService: ElectronicBillingService;
+  private readonly _wsfecredService: WsfecredService;
+  private readonly _wsfexService: WsfexService;
   private readonly _registerInscriptionProofService: RegisterInscriptionProofService;
   private readonly _registerScopeFourService: RegisterScopeFourService;
   private readonly _registerScopeFiveService: RegisterScopeFiveService;
@@ -81,6 +87,16 @@ export class Arca {
         useSoap12: this.context.useSoap12 ?? true, // Default to SOAP 1.2
       });
 
+    const wsfexRepository = new WsfexRepository({
+      ...baseRepositoryConfig,
+      useSoap12: this.context.useSoap12 ?? true,
+    });
+
+    const wsfecredRepository = new WsfecredRepository({
+      ...baseRepositoryConfig,
+      useSoap12: false,
+    });
+
     const registerScopeFourRepository = new RegisterScopeFourRepository(
       baseRepositoryConfig
     );
@@ -108,6 +124,8 @@ export class Arca {
     this._electronicBillingService = new ElectronicBillingService(
       electronicBillingRepository
     );
+    this._wsfecredService = new WsfecredService(wsfecredRepository);
+    this._wsfexService = new WsfexService(wsfexRepository);
     this._registerInscriptionProofService = new RegisterInscriptionProofService(
       registerInscriptionProofRepository
     );
@@ -128,6 +146,14 @@ export class Arca {
 
   get electronicBillingService(): ElectronicBillingService {
     return this._electronicBillingService;
+  }
+
+  get wsfecredService(): WsfecredService {
+    return this._wsfecredService;
+  }
+
+  get wsfexService(): WsfexService {
+    return this._wsfexService;
   }
 
   get registerInscriptionProofService(): RegisterInscriptionProofService {

--- a/packages/core/src/infrastructure/outbound/adapters/enums.ts
+++ b/packages/core/src/infrastructure/outbound/adapters/enums.ts
@@ -12,6 +12,18 @@ export enum EndpointsEnum {
   WSFEV1_TEST = "https://wswhomo.afip.gov.ar/wsfev1/service.asmx",
 
   /**
+   * WS Facturacion Electronica de Exportacion
+   **/
+  WSFEX = "https://servicios1.afip.gov.ar/wsfexv1/service.asmx",
+  WSFEX_TEST = "https://wswhomo.afip.gov.ar/wsfexv1/service.asmx",
+
+  /**
+   * WS Factura de Crédito Electrónica
+   **/
+  WSFECRED = "https://serviciosjava.afip.gob.ar/wsfecred/FECredService",
+  WSFECRED_TEST = "https://fwshomo.afip.gov.ar/wsfecred/FECredService",
+
+  /**
    * WS Constancia inscripción
    **/
   WSSR_INSCRIPTION_PROOF = "https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA5",

--- a/packages/core/src/infrastructure/outbound/adapters/fecred/fecred-repository.ts
+++ b/packages/core/src/infrastructure/outbound/adapters/fecred/fecred-repository.ts
@@ -1,0 +1,388 @@
+/**
+ * WSFEcred Repository
+ * Implements IWsfecredRepositoryPort for Factura de Crédito Electrónica
+ */
+import { BaseSoapRepository } from "../soap/base-soap-repository";
+import { BaseSoapRepositoryConstructorConfig } from "@infrastructure/outbound/ports/soap/soap-repository.types";
+import { IWsfecredRepositoryPort } from "@application/ports/fecred/fecred-repository.port";
+import {
+  FecredAcceptRequestDto,
+  FecredAcceptResultDto,
+  FecredConsultarComprobantesRequestDto,
+  FecredConsultarComprobantesResultDto,
+  FecredConsultarCtaCteRequestDto,
+  FecredConsultarCtaCteResultDto,
+  FecredConsultarCtasCtesRequestDto,
+  FecredConsultarCtasCtesResultDto,
+  FecredConsultarCuentasEnAgtDptoCltvRequestDto,
+  FecredConsultarCuentasEnAgtDptoCltvResultDto,
+  FecredConsultarFacturasAgtDptoCltvRequestDto,
+  FecredConsultarFacturasAgtDptoCltvResultDto,
+  FecredConsultarHistorialEstadosComprobanteRequestDto,
+  FecredConsultarHistorialEstadosComprobanteResultDto,
+  FecredConsultarHistorialEstadosCtaCteRequestDto,
+  FecredConsultarHistorialEstadosCtaCteResultDto,
+  FecredConsultarMontoObligadoRecepcionRequestDto,
+  FecredConsultarMontoObligadoRecepcionResultDto,
+  FecredConsultarObligadoRecepcionRequestDto,
+  FecredConsultarObligadoRecepcionResultDto,
+  FecredConsultarTiposAjustesOperacionRequestDto,
+  FecredConsultarTiposAjustesOperacionResultDto,
+  FecredConsultarTiposFormasCancelacionRequestDto,
+  FecredConsultarTiposFormasCancelacionResultDto,
+  FecredConsultarTiposMotivosRechazoRequestDto,
+  FecredConsultarTiposMotivosRechazoResultDto,
+  FecredConsultarTiposRetencionesRequestDto,
+  FecredConsultarTiposRetencionesResultDto,
+  FecredInformCancelacionTotalRequestDto,
+  FecredInformCancelacionTotalResultDto,
+  FecredInformFacturaAgtDptoCltvRequestDto,
+  FecredInformFacturaAgtDptoCltvResultDto,
+  FecredModifyTransferOptionRequestDto,
+  FecredModifyTransferOptionResultDto,
+  FecredObtenerRemitosRequestDto,
+  FecredObtenerRemitosResultDto,
+  FecredRejectNoteRequestDto,
+  FecredRejectNoteResultDto,
+  FecredRejectRequestDto,
+  FecredRejectResultDto,
+  FecredServerStatusDto,
+} from "@application/dto/fecred.dto";
+import { ServiceNamesEnum } from "@infrastructure/outbound/ports/soap/enums/service-names.enum";
+import { WsdlPathEnum } from "@infrastructure/outbound/ports/soap/enums/wsdl-path.enum";
+import {
+  EndpointsEnum,
+  SoapServiceVersion,
+} from "@infrastructure/outbound/ports/soap/enums/endpoints.enum";
+import { IFECredServiceSoap } from "@infrastructure/outbound/ports/soap/interfaces/FECredService/ServiceSoap";
+
+export class WsfecredRepository
+  extends BaseSoapRepository
+  implements IWsfecredRepositoryPort
+{
+  private client?: IFECredServiceSoap;
+
+  constructor(config: BaseSoapRepositoryConstructorConfig) {
+    super(config);
+  }
+
+  private async getClient(): Promise<IFECredServiceSoap> {
+    if (this.client) {
+      return this.client;
+    }
+
+    const wsdlName = this.production
+      ? WsdlPathEnum.WSFECRED
+      : WsdlPathEnum.WSFECRED_TEST;
+    const endpoint = this.production
+      ? EndpointsEnum.WSFECRED
+      : EndpointsEnum.WSFECRED_TEST;
+
+    const client = await this.soapClient.createClient<IFECredServiceSoap>(
+      wsdlName,
+      {
+        forceSoap12Headers: false,
+      }
+    );
+
+    this.soapClient.setEndpoint(client, endpoint);
+
+    this.client = this.createAuthenticatedProxy(client, {
+      serviceName: ServiceNamesEnum.WSFECRED,
+      injectAuthProperty: false,
+      soapVersion: SoapServiceVersion.ServiceSoap,
+      authMapper: (auth: any) => ({
+        authRequest: {
+          token: auth.Auth.Token,
+          sign: auth.Auth.Sign,
+          cuitRepresentada: auth.Auth.Cuit,
+        },
+      }),
+      excludeMethods: ["dummy"],
+    }) as IFECredServiceSoap;
+
+    return this.client;
+  }
+
+  private unwrapReturn<T>(
+    output: any,
+    returnKey: string,
+    responseKey?: string
+  ): T {
+    if (output?.[returnKey] !== undefined) {
+      return output[returnKey] as T;
+    }
+
+    if (responseKey && output?.[responseKey]?.[returnKey] !== undefined) {
+      return output[responseKey][returnKey] as T;
+    }
+
+    if (responseKey && output?.[responseKey] !== undefined) {
+      return output[responseKey] as T;
+    }
+
+    return output as T;
+  }
+
+  async getServerStatus(): Promise<FecredServerStatusDto> {
+    const client = await this.getClient();
+    const [output] = await client.dummyAsync({});
+    const result = output?.dummyReturn ?? output?.dummyResponse?.dummyReturn;
+
+    return {
+      appserver: result?.appserver ?? "",
+      dbserver: result?.dbserver ?? "",
+      authserver: result?.authserver ?? "",
+    };
+  }
+
+  async aceptarFECred(
+    params: FecredAcceptRequestDto
+  ): Promise<FecredAcceptResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.aceptarFECredAsync(params as any);
+    return this.unwrapReturn(output, "operacionFECredReturn", "aceptarFECredResponse");
+  }
+
+  async rechazarFECred(
+    params: FecredRejectRequestDto
+  ): Promise<FecredRejectResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.rechazarFECredAsync(params as any);
+    return this.unwrapReturn(output, "operacionFECredReturn", "rechazarFECredResponse");
+  }
+
+  async rechazarNotaDC(
+    params: FecredRejectNoteRequestDto
+  ): Promise<FecredRejectNoteResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.rechazarNotaDCAsync(params as any);
+    return this.unwrapReturn(output, "rechazarNotaDCReturn", "rechazarNotaDCResponse");
+  }
+
+  async informarFacturaAgtDptoCltv(
+    params: FecredInformFacturaAgtDptoCltvRequestDto
+  ): Promise<FecredInformFacturaAgtDptoCltvResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.informarFacturaAgtDptoCltvAsync(params as any);
+    return this.unwrapReturn(
+      output,
+      "operacionFECredReturn",
+      "informarFacturaAgtDptoCltvResponse"
+    );
+  }
+
+  async informarCancelacionTotalFECred(
+    params: FecredInformCancelacionTotalRequestDto
+  ): Promise<FecredInformCancelacionTotalResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.informarCancelacionTotalFECredAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "operacionFECredReturn",
+      "informarCancelacionTotalFECredResponse"
+    );
+  }
+
+  async modificarOpcionTransferencia(
+    params: FecredModifyTransferOptionRequestDto
+  ): Promise<FecredModifyTransferOptionResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.modificarOpcionTransferenciaAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "operacionFECredReturn",
+      "modificarOpcionTransferenciaResponse"
+    );
+  }
+
+  async consultarComprobantes(
+    params: FecredConsultarComprobantesRequestDto
+  ): Promise<FecredConsultarComprobantesResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarComprobantesAsync(params as any);
+    return this.unwrapReturn(
+      output,
+      "consultarCmpReturn",
+      "consultarComprobantesResponse"
+    );
+  }
+
+  async consultarCtaCte(
+    params: FecredConsultarCtaCteRequestDto
+  ): Promise<FecredConsultarCtaCteResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarCtaCteAsync(params as any);
+    return this.unwrapReturn(
+      output,
+      "consultarCtaCteReturn",
+      "consultarCtaCteResponse"
+    );
+  }
+
+  async consultarCtasCtes(
+    params: FecredConsultarCtasCtesRequestDto
+  ): Promise<FecredConsultarCtasCtesResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarCtasCtesAsync(params as any);
+    return this.unwrapReturn(
+      output,
+      "consultarCtasCtesReturn",
+      "consultarCtasCtesResponse"
+    );
+  }
+
+  async consultarCuentasEnAgtDptoCltv(
+    params: FecredConsultarCuentasEnAgtDptoCltvRequestDto
+  ): Promise<FecredConsultarCuentasEnAgtDptoCltvResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarCuentasEnAgtDptoCltvAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "consultarCuentasEnAgtDptoCltvReturn",
+      "consultarCuentasEnAgtDptoCltvResponse"
+    );
+  }
+
+  async consultarFacturasAgtDptoCltv(
+    params: FecredConsultarFacturasAgtDptoCltvRequestDto
+  ): Promise<FecredConsultarFacturasAgtDptoCltvResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarFacturasAgtDptoCltvAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "consultarFacturasAgtDptoCltvReturn",
+      "consultarFacturasAgtDptoCltvResponse"
+    );
+  }
+
+  async consultarHistorialEstadosComprobante(
+    params: FecredConsultarHistorialEstadosComprobanteRequestDto
+  ): Promise<FecredConsultarHistorialEstadosComprobanteResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarHistorialEstadosComprobanteAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "consultarHistorialEstadosComprobanteReturn",
+      "consultarHistorialEstadosComprobanteResponse"
+    );
+  }
+
+  async consultarHistorialEstadosCtaCte(
+    params: FecredConsultarHistorialEstadosCtaCteRequestDto
+  ): Promise<FecredConsultarHistorialEstadosCtaCteResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarHistorialEstadosCtaCteAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "consultarHistorialEstadosCtaCteReturn",
+      "consultarHistorialEstadosCtaCteResponse"
+    );
+  }
+
+  async consultarMontoObligadoRecepcion(
+    params: FecredConsultarMontoObligadoRecepcionRequestDto
+  ): Promise<FecredConsultarMontoObligadoRecepcionResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarMontoObligadoRecepcionAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "consultarMontoObligadoRecepcionReturn",
+      "consultarMontoObligadoRecepcionResponse"
+    );
+  }
+
+  async consultarObligadoRecepcion(
+    params: FecredConsultarObligadoRecepcionRequestDto
+  ): Promise<FecredConsultarObligadoRecepcionResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarMontoObligadoRecepcionAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "consultarMontoObligadoRecepcionReturn",
+      "consultarMontoObligadoRecepcionResponse"
+    );
+  }
+
+  async consultarTiposAjustesOperacion(
+    params: FecredConsultarTiposAjustesOperacionRequestDto
+  ): Promise<FecredConsultarTiposAjustesOperacionResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarTiposAjustesOperacionAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "codigoDescripcionReturn",
+      "consultarTiposAjustesOperacionResponse"
+    );
+  }
+
+  async consultarTiposFormasCancelacion(
+    params: FecredConsultarTiposFormasCancelacionRequestDto
+  ): Promise<FecredConsultarTiposFormasCancelacionResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarTiposFormasCancelacionAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "codigoDescripcionReturn",
+      "consultarTiposFormasCancelacionResponse"
+    );
+  }
+
+  async consultarTiposMotivosRechazo(
+    params: FecredConsultarTiposMotivosRechazoRequestDto
+  ): Promise<FecredConsultarTiposMotivosRechazoResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarTiposMotivosRechazoAsync(
+      params as any
+    );
+    return this.unwrapReturn(
+      output,
+      "codigoDescripcionReturn",
+      "consultarTiposMotivosRechazoResponse"
+    );
+  }
+
+  async consultarTiposRetenciones(
+    params: FecredConsultarTiposRetencionesRequestDto
+  ): Promise<FecredConsultarTiposRetencionesResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.consultarTiposRetencionesAsync(params as any);
+    return this.unwrapReturn(
+      output,
+      "consultarTiposRetencionesReturn",
+      "consultarTiposRetencionesResponse"
+    );
+  }
+
+  async obtenerRemitos(
+    params: FecredObtenerRemitosRequestDto
+  ): Promise<FecredObtenerRemitosResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.obtenerRemitosAsync(params as any);
+    return this.unwrapReturn(
+      output,
+      "obtenerRemitosReturn",
+      "obtenerRemitosResponse"
+    );
+  }
+}

--- a/packages/core/src/infrastructure/outbound/adapters/fecred/index.ts
+++ b/packages/core/src/infrastructure/outbound/adapters/fecred/index.ts
@@ -1,0 +1,4 @@
+/**
+ * WSFEcred Outbound Adapter
+ */
+export * from "./fecred-repository";

--- a/packages/core/src/infrastructure/outbound/adapters/fex/fex-repository.ts
+++ b/packages/core/src/infrastructure/outbound/adapters/fex/fex-repository.ts
@@ -1,0 +1,243 @@
+/**
+ * WSFEX Repository
+ * Implements IWsfexRepositoryPort for Export Electronic Billing
+ */
+import { BaseSoapRepository } from "../soap/base-soap-repository";
+import { BaseSoapRepositoryConstructorConfig } from "@infrastructure/outbound/ports/soap/soap-repository.types";
+import { IWsfexRepositoryPort } from "@application/ports/fex/fex-repository.port";
+import {
+  FexAuthorizeRequestDto,
+  FexAuthorizeResultDto,
+  FexCheckPermisoRequestDto,
+  FexCheckPermisoResultDto,
+  FexGetCmpRequestDto,
+  FexGetCmpResultDto,
+  FexGetLastCmpRequestDto,
+  FexGetLastCmpResultDto,
+  FexGetLastIdResultDto,
+  FexGetParamCtzRequestDto,
+  FexParamActividadesResultDto,
+  FexParamCbteTipoResultDto,
+  FexParamCtzResultDto,
+  FexParamDstCuitResultDto,
+  FexParamDstPaisResultDto,
+  FexParamIdiomasResultDto,
+  FexParamIncotermsResultDto,
+  FexParamMonCotizacionRequestDto,
+  FexParamMonCotizacionResultDto,
+  FexParamMonResultDto,
+  FexParamOpcionalesResultDto,
+  FexParamPtoVentaResultDto,
+  FexParamTipoExpoResultDto,
+  FexParamUmedResultDto,
+  FexServerStatusDto,
+} from "@application/dto/fex.dto";
+import { ServiceNamesEnum } from "@infrastructure/outbound/ports/soap/enums/service-names.enum";
+import { WsdlPathEnum } from "@infrastructure/outbound/ports/soap/enums/wsdl-path.enum";
+import {
+  EndpointsEnum,
+  SoapServiceVersion,
+} from "@infrastructure/outbound/ports/soap/enums/endpoints.enum";
+import { IFEXServiceSoap } from "@infrastructure/outbound/ports/soap/interfaces/FEXService/ServiceSoap";
+import { IFEXServiceSoap12 } from "@infrastructure/outbound/ports/soap/interfaces/FEXService/ServiceSoap12";
+
+export class WsfexRepository
+  extends BaseSoapRepository
+  implements IWsfexRepositoryPort
+{
+  private client?: IFEXServiceSoap | IFEXServiceSoap12;
+
+  constructor(config: BaseSoapRepositoryConstructorConfig) {
+    super(config);
+  }
+
+  private async getClient(): Promise<IFEXServiceSoap | IFEXServiceSoap12> {
+    if (this.client) {
+      return this.client;
+    }
+
+    const wsdlName = this.production
+      ? WsdlPathEnum.WSFEX
+      : WsdlPathEnum.WSFEX_TEST;
+    const endpoint = this.production
+      ? EndpointsEnum.WSFEX
+      : EndpointsEnum.WSFEX_TEST;
+
+    let client: IFEXServiceSoap | IFEXServiceSoap12;
+    let soapVersion: SoapServiceVersion;
+
+    if (this.useSoap12) {
+      client = await this.soapClient.createClient<IFEXServiceSoap12>(
+        wsdlName,
+        {
+          forceSoap12Headers: true,
+        }
+      );
+      soapVersion = SoapServiceVersion.ServiceSoap12;
+    } else {
+      client = await this.soapClient.createClient<IFEXServiceSoap>(wsdlName, {
+        forceSoap12Headers: false,
+      });
+      soapVersion = SoapServiceVersion.ServiceSoap;
+    }
+
+    this.soapClient.setEndpoint(client, endpoint);
+
+    this.client = this.createAuthenticatedProxy(client, {
+      serviceName: ServiceNamesEnum.WSFEX,
+      injectAuthProperty: false,
+      soapVersion,
+      excludeMethods: ["FEXGetLast_CMP"],
+    }) as IFEXServiceSoap | IFEXServiceSoap12;
+
+    return this.client;
+  }
+
+  async getServerStatus(): Promise<FexServerStatusDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXDummyAsync({});
+    const result = output.FEXDummyResult;
+
+    return {
+      appserver: result?.AppServer ?? "",
+      dbserver: result?.DbServer ?? "",
+      authserver: result?.AuthServer ?? "",
+    };
+  }
+
+  async authorize(cmp: FexAuthorizeRequestDto): Promise<FexAuthorizeResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXAuthorizeAsync({ Cmp: cmp });
+    return output.FEXAuthorizeResult;
+  }
+
+  async getCmp(params: FexGetCmpRequestDto): Promise<FexGetCmpResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetCMPAsync({ Cmp: params });
+    return output.FEXGetCMPResult;
+  }
+
+  async getLastCmp(
+    params: FexGetLastCmpRequestDto
+  ): Promise<FexGetLastCmpResultDto> {
+    const client = await this.getClient();
+    const ticket = await this.authRepository.login(ServiceNamesEnum.WSFEX);
+    const auth = this.authRepository.getAuthParams(ticket, this.cuit).Auth;
+
+    const [output] = await client.FEXGetLast_CMPAsync({
+      Auth: {
+        Token: auth.Token,
+        Sign: auth.Sign,
+        Cuit: auth.Cuit,
+        Pto_venta: params.Pto_venta,
+        Cbte_Tipo: params.Cbte_Tipo,
+      },
+    });
+
+    return output.FEXGetLast_CMPResult;
+  }
+
+  async getLastId(): Promise<FexGetLastIdResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetLast_IDAsync({});
+    return output.FEXGetLast_IDResult;
+  }
+
+  async checkPermiso(
+    params: FexCheckPermisoRequestDto
+  ): Promise<FexCheckPermisoResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXCheck_PermisoAsync({
+      ID_Permiso: params.ID_Permiso,
+      Dst_merc: params.Dst_merc,
+    });
+    return output.FEXCheck_PermisoResult;
+  }
+
+  async getParamPtoVenta(): Promise<FexParamPtoVentaResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_PtoVentaAsync({});
+    return output.FEXGetPARAM_PtoVentaResult;
+  }
+
+  async getParamCbteTipo(): Promise<FexParamCbteTipoResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_Cbte_TipoAsync({});
+    return output.FEXGetPARAM_Cbte_TipoResult;
+  }
+
+  async getParamTipoExpo(): Promise<FexParamTipoExpoResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_Tipo_ExpoAsync({});
+    return output.FEXGetPARAM_Tipo_ExpoResult;
+  }
+
+  async getParamIncoterms(): Promise<FexParamIncotermsResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_IncotermsAsync({});
+    return output.FEXGetPARAM_IncotermsResult;
+  }
+
+  async getParamIdiomas(): Promise<FexParamIdiomasResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_IdiomasAsync({});
+    return output.FEXGetPARAM_IdiomasResult;
+  }
+
+  async getParamUmed(): Promise<FexParamUmedResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_UMedAsync({});
+    return output.FEXGetPARAM_UMedResult;
+  }
+
+  async getParamDstPais(): Promise<FexParamDstPaisResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_DST_paisAsync({});
+    return output.FEXGetPARAM_DST_paisResult;
+  }
+
+  async getParamDstCuit(): Promise<FexParamDstCuitResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_DST_CUITAsync({});
+    return output.FEXGetPARAM_DST_CUITResult;
+  }
+
+  async getParamMon(): Promise<FexParamMonResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_MONAsync({});
+    return output.FEXGetPARAM_MONResult;
+  }
+
+  async getParamMonCotizacion(
+    params?: FexParamMonCotizacionRequestDto
+  ): Promise<FexParamMonCotizacionResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_MON_CON_COTIZACIONAsync({
+      Fecha_CTZ: params?.Fecha_CTZ,
+    });
+    return output.FEXGetPARAM_MON_CON_COTIZACIONResult;
+  }
+
+  async getParamCtz(
+    params?: FexGetParamCtzRequestDto
+  ): Promise<FexParamCtzResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_CtzAsync({
+      Mon_id: params?.Mon_id,
+      FchCotiz: params?.FchCotiz,
+    });
+    return output.FEXGetPARAM_CtzResult;
+  }
+
+  async getParamOpcionales(): Promise<FexParamOpcionalesResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_OpcionalesAsync({});
+    return output.FEXGetPARAM_OpcionalesResult;
+  }
+
+  async getParamActividades(): Promise<FexParamActividadesResultDto> {
+    const client = await this.getClient();
+    const [output] = await client.FEXGetPARAM_ActividadesAsync({});
+    return output.FEXGetPARAM_ActividadesResult;
+  }
+}

--- a/packages/core/src/infrastructure/outbound/adapters/fex/index.ts
+++ b/packages/core/src/infrastructure/outbound/adapters/fex/index.ts
@@ -1,0 +1,1 @@
+export * from "./fex-repository";

--- a/packages/core/src/infrastructure/outbound/adapters/index.ts
+++ b/packages/core/src/infrastructure/outbound/adapters/index.ts
@@ -7,4 +7,6 @@ export * from "./auth/auth.repository";
 export * from "./storage/file-system-ticket-storage";
 export * from "./logger/winston-logger";
 export * from "./electronic-billing";
+export * from "./fecred";
+export * from "./fex";
 export * from "./register";

--- a/packages/core/src/infrastructure/outbound/adapters/soap/wsdl-strings.ts
+++ b/packages/core/src/infrastructure/outbound/adapters/soap/wsdl-strings.ts
@@ -8,2824 +8,6 @@
  */
 
 export const WSDL_STRINGS: Record<string, string> = {
-  'ws_sr_inscription_proof-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
-  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
-  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
-  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
-  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosGenerales">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="caracterizacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="actividad">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
-      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="categoria">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="relacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="impuesto">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="regimen">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorConstancia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaListResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaListReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaListResponse">
-    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2Response">
-    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2Response">
-    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList">
-    <wsdl:part element="tns:getPersonaList" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2">
-    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2">
-    <wsdl:part element="tns:getPersona_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA5">
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaListResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersona_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaList_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA5">
-    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
-      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_inscription_proof.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
-  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
-  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
-  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
-  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosGenerales">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="caracterizacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="actividad">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
-      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="categoria">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="relacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="impuesto">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="regimen">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorConstancia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaListResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaListReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaListResponse">
-    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2Response">
-    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2Response">
-    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList">
-    <wsdl:part element="tns:getPersonaList" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2">
-    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2">
-    <wsdl:part element="tns:getPersona_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA5">
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaListResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersona_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaList_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA5">
-    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
-      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a10-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA10" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA10">
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA10SoapBinding" type="tns:PersonaServiceA10">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA10">
-    <wsdl:port binding="tns:PersonaServiceA10SoapBinding" name="PersonaServiceA10Port">
-      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA10"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a10.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA10" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA10">
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA10SoapBinding" type="tns:PersonaServiceA10">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA10">
-    <wsdl:port binding="tns:PersonaServiceA10SoapBinding" name="PersonaServiceA10Port">
-      <soap:address location="http://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA10"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a13-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA13" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getIdPersonaListByDocumento" type="tns:getIdPersonaListByDocumento"/>
-  <xs:element name="getIdPersonaListByDocumentoResponse" type="tns:getIdPersonaListByDocumentoResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getIdPersonaListByDocumento">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="documento" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getIdPersonaListByDocumentoResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="idPersonaListReturn" type="tns:idPersonaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="idPersonaListReturn">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="idPersona" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="periodoActividadPrincipal" type="xs:int"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="calle" type="xs:string"/>
-      <xs:element minOccurs="0" name="codigoPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoDomicilio" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="manzana" type="xs:string"/>
-      <xs:element minOccurs="0" name="numero" type="xs:int"/>
-      <xs:element minOccurs="0" name="oficinaDptoLocal" type="xs:string"/>
-      <xs:element minOccurs="0" name="piso" type="xs:string"/>
-      <xs:element minOccurs="0" name="sector" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-      <xs:element minOccurs="0" name="torre" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getIdPersonaListByDocumento">
-    <wsdl:part element="tns:getIdPersonaListByDocumento" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getIdPersonaListByDocumentoResponse">
-    <wsdl:part element="tns:getIdPersonaListByDocumentoResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA13">
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getIdPersonaListByDocumento">
-      <wsdl:input message="tns:getIdPersonaListByDocumento" name="getIdPersonaListByDocumento">
-    </wsdl:input>
-      <wsdl:output message="tns:getIdPersonaListByDocumentoResponse" name="getIdPersonaListByDocumentoResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA13SoapBinding" type="tns:PersonaServiceA13">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getIdPersonaListByDocumento">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getIdPersonaListByDocumento">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getIdPersonaListByDocumentoResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA13">
-    <wsdl:port binding="tns:PersonaServiceA13SoapBinding" name="PersonaServiceA13Port">
-      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA13"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a13.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA13" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getIdPersonaListByDocumento" type="tns:getIdPersonaListByDocumento"/>
-  <xs:element name="getIdPersonaListByDocumentoResponse" type="tns:getIdPersonaListByDocumentoResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getIdPersonaListByDocumento">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="documento" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getIdPersonaListByDocumentoResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="idPersonaListReturn" type="tns:idPersonaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="idPersonaListReturn">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="idPersona" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="periodoActividadPrincipal" type="xs:int"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="calle" type="xs:string"/>
-      <xs:element minOccurs="0" name="codigoPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoDomicilio" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="manzana" type="xs:string"/>
-      <xs:element minOccurs="0" name="numero" type="xs:int"/>
-      <xs:element minOccurs="0" name="oficinaDptoLocal" type="xs:string"/>
-      <xs:element minOccurs="0" name="piso" type="xs:string"/>
-      <xs:element minOccurs="0" name="sector" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-      <xs:element minOccurs="0" name="torre" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getIdPersonaListByDocumento">
-    <wsdl:part element="tns:getIdPersonaListByDocumento" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getIdPersonaListByDocumentoResponse">
-    <wsdl:part element="tns:getIdPersonaListByDocumentoResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA13">
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getIdPersonaListByDocumento">
-      <wsdl:input message="tns:getIdPersonaListByDocumento" name="getIdPersonaListByDocumento">
-    </wsdl:input>
-      <wsdl:output message="tns:getIdPersonaListByDocumentoResponse" name="getIdPersonaListByDocumentoResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA13SoapBinding" type="tns:PersonaServiceA13">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getIdPersonaListByDocumento">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getIdPersonaListByDocumento">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getIdPersonaListByDocumentoResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA13">
-    <wsdl:port binding="tns:PersonaServiceA13SoapBinding" name="PersonaServiceA13Port">
-      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA13"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a4-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA4" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element minOccurs="0" name="cantidadSociosEmpresaMono" type="xs:int"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="categoria" nillable="true" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="email" nillable="true" type="tns:email"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaInscripcion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaJubilado" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaVencimientoMigracion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-      <xs:element minOccurs="0" name="leyJubilacion" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidadInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="organismoInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="organismoOriginante" type="xs:string"/>
-      <xs:element minOccurs="0" name="porcentajeCapitalNacional" type="xs:double"/>
-      <xs:element minOccurs="0" name="provinciaInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="relacion" nillable="true" type="tns:relacion"/>
-      <xs:element minOccurs="0" name="sexo" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="telefono" nillable="true" type="tns:telefono"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoOrganismoOriginante" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoResidencia" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="actividad">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
-      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="categoria">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="email">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoEmail" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="impuesto">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="ffInscripcion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="regimen">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
-      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="relacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
-      <xs:element minOccurs="0" name="subtipoRelacion" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoRelacion" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="telefono">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="numero" type="xs:long"/>
-      <xs:element minOccurs="0" name="tipoLinea" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoTelefono" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA4">
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA4SoapBinding" type="tns:PersonaServiceA4">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA4">
-    <wsdl:port binding="tns:PersonaServiceA4SoapBinding" name="PersonaServiceA4Port">
-      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA4"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a4.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA4" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element minOccurs="0" name="cantidadSociosEmpresaMono" type="xs:int"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="categoria" nillable="true" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="email" nillable="true" type="tns:email"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaInscripcion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaJubilado" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaVencimientoMigracion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-      <xs:element minOccurs="0" name="leyJubilacion" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidadInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="numeroInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="organismoInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="organismoOriginante" type="xs:string"/>
-      <xs:element minOccurs="0" name="porcentajeCapitalNacional" type="xs:double"/>
-      <xs:element minOccurs="0" name="provinciaInscripcion" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="relacion" nillable="true" type="tns:relacion"/>
-      <xs:element minOccurs="0" name="sexo" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="telefono" nillable="true" type="tns:telefono"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoOrganismoOriginante" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoResidencia" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="actividad">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
-      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="categoria">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="email">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoEmail" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="impuesto">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="ffInscripcion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="regimen">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
-      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="estado" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="relacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
-      <xs:element minOccurs="0" name="subtipoRelacion" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoRelacion" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="telefono">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="numero" type="xs:long"/>
-      <xs:element minOccurs="0" name="tipoLinea" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoTelefono" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA4">
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA4SoapBinding" type="tns:PersonaServiceA4">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA4">
-    <wsdl:port binding="tns:PersonaServiceA4SoapBinding" name="PersonaServiceA4Port">
-      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA4"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a5-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
-  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
-  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
-  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
-  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosGenerales">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="caracterizacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="actividad">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
-      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="categoria">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="relacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="impuesto">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="regimen">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorConstancia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaListResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaListReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaListResponse">
-    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2Response">
-    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2Response">
-    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList">
-    <wsdl:part element="tns:getPersonaList" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2">
-    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2">
-    <wsdl:part element="tns:getPersona_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA5">
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaListResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersona_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaList_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA5">
-    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
-      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
-  'ws_sr_padron_a5.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <wsdl:types>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="dummy" type="tns:dummy"/>
-  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
-  <xs:element name="getPersona" type="tns:getPersona"/>
-  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
-  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
-  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
-  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
-  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
-  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
-  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
-  <xs:complexType name="getPersona">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosGenerales">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
-      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
-      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
-      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="caracterizacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dependencia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="domicilio">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
-      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
-      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
-      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
-      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="actividad">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
-      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
-      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
-      <xs:element minOccurs="0" name="orden" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="categoria">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
-      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="relacion">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
-      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="impuesto">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="datosRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
-      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="regimen">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
-      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
-      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
-      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
-      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorConstancia">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
-      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorMonotributo">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="errorRegimenGeneral">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
-      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="metadata">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
-      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaListResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="personaListReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
-      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="persona">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
-      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
-      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
-      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
-      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
-      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersona_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummy">
-    <xs:sequence/>
-  </xs:complexType>
-  <xs:complexType name="dummyResponse">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="dummyReturn">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
-      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2">
-    <xs:sequence>
-      <xs:element name="token" type="xs:string"/>
-      <xs:element name="sign" type="xs:string"/>
-      <xs:element name="cuitRepresentada" type="xs:long"/>
-      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="getPersonaList_v2Response">
-    <xs:sequence>
-      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
-  <xs:complexType name="SRValidationException">
-    <xs:sequence/>
-  </xs:complexType>
-</xs:schema>
-  </wsdl:types>
-  <wsdl:message name="getPersonaListResponse">
-    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummyResponse">
-    <wsdl:part element="tns:dummyResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona">
-    <wsdl:part element="tns:getPersona" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2Response">
-    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2Response">
-    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList">
-    <wsdl:part element="tns:getPersonaList" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaResponse">
-    <wsdl:part element="tns:getPersonaResponse" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="dummy">
-    <wsdl:part element="tns:dummy" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersonaList_v2">
-    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="SRValidationException">
-    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:message name="getPersona_v2">
-    <wsdl:part element="tns:getPersona_v2" name="parameters">
-    </wsdl:part>
-  </wsdl:message>
-  <wsdl:portType name="PersonaServiceA5">
-    <wsdl:operation name="getPersona">
-      <wsdl:input message="tns:getPersona" name="getPersona">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <wsdl:input message="tns:dummy" name="dummy">
-    </wsdl:input>
-      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
-    </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
-    </wsdl:input>
-      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
-    </wsdl:output>
-      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
-    </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:portType>
-  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-    <wsdl:operation name="getPersona">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaListResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="getPersona_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersona_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersona_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-    <wsdl:operation name="dummy">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="dummy">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="dummyResponse">
-        <soap:body use="literal"/>
-      </wsdl:output>
-    </wsdl:operation>
-    <wsdl:operation name="getPersonaList_v2">
-      <soap:operation soapAction="" style="document"/>
-      <wsdl:input name="getPersonaList_v2">
-        <soap:body use="literal"/>
-      </wsdl:input>
-      <wsdl:output name="getPersonaList_v2Response">
-        <soap:body use="literal"/>
-      </wsdl:output>
-      <wsdl:fault name="SRValidationException">
-        <soap:fault name="SRValidationException" use="literal"/>
-      </wsdl:fault>
-    </wsdl:operation>
-  </wsdl:binding>
-  <wsdl:service name="PersonaServiceA5">
-    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
-      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
-    </wsdl:port>
-  </wsdl:service>
-</wsdl:definitions>`,
   'wsaa.wsdl': `<?xml version="1.0" encoding="UTF-8"?>
 <wsdl:definitions targetNamespace="https://wsaahomo.afip.gov.ar/ws/services/LoginCms" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="https://wsaahomo.afip.gov.ar/ws/services/LoginCms" xmlns:intf="https://wsaahomo.afip.gov.ar/ws/services/LoginCms" xmlns:tns1="http://wsaa.view.sua.dvadac.desein.afip.gov" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 <!--WSDL created by Apache Axis version: 1.4
@@ -6131,6 +3313,9088 @@ Built on Apr 22, 2006 (06:55:48 PDT)-->
     </wsdl:port>
     <wsdl:port name="ServiceSoap12" binding="tns:ServiceSoap12">
       <soap12:address location="https://wswhomo.afip.gov.ar/wsfev1/service.asmx" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'wsfecred-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://ar.gob.afip.wsfecred/FECredService/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="FECredService" targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+			<xsd:element name="dummyResponse" type="tns:DummyResponseType" />
+			<xsd:complexType name="DummyResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="dummyReturn" type="tns:DummyReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="DummyReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="appserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="authserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="dbserver" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="AuthRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="token" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="sign" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitRepresentada" type="tns:CuitSimpleType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="CuitSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minExclusive value="9999999999" />
+					<xsd:maxInclusive value="99999999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ArrayCodigosDescripcionesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcion" type="tns:CodigoDescripcionType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ArrayCodigosDescripcionesStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcionString" type="tns:CodigoDescripcionStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+
+
+			<xsd:element name="consultarComprobantesRequest" type="tns:ConsultarComprobanteRequestType" />
+			<xsd:element name="consultarComprobantesResponse" type="tns:ConsultarComprobantesResponseType" />
+			<xsd:complexType name="ConsultarComprobanteRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCmp" type="tns:EstadoCmpSimpleType" />
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType" />
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="codCtaCte" type="xsd:long" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarComprobantesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCmpReturn" type="tns:ConsultarCmpReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarCmpReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayComprobantes" type="tns:ArrayComprobantesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+	            	</xsd:element>
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:simpleType name="ResultadoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="O" />
+					<xsd:enumeration value="R" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="NumeroComprobanteSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="PuntoVentaSimpleType">
+				<xsd:restriction base="xsd:int">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:element name="rechazarFECredRequest" type="tns:RechazarFECredRequestType" />
+			<xsd:element name="rechazarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="RechazarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarCtaCteRequest" type="tns:ConsultarCtaCteRequestType" />
+			<xsd:element name="consultarCtaCteResponse" type="tns:ConsultarCtaCteResponseType" />
+			<xsd:complexType name="ConsultarCtaCteRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:element name="rechazarNotaDCRequest" type="tns:RechazarNotaDCRequestType">
+			</xsd:element>
+			<xsd:element name="rechazarNotaDCResponse" type="tns:RechazarNotaDCResponseType" />
+			<xsd:complexType name="RechazarNotaDCRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="informarFacturaAgtDptoCltvRequest" type="tns:InformarFacturaAgtDptoCltvRequestType" />
+			<xsd:element name="informarFacturaAgtDptoCltvResponse" type="tns:OperacionFECredResponseType" />
+			
+			<xsd:element name="consultarCuentasEnAgtDptoCltvRequest" type="tns:ConsultarCuentasEnAgtDptoCltvRequestType" />
+			<xsd:element name="consultarCuentasEnAgtDptoCltvResponse" type="tns:consultarCuentasEnAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="Texto250SimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="3" />
+					<xsd:maxLength value="250" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+
+
+			<xsd:element name="consultarTiposRetencionesRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposRetencionesResponse" type="tns:ConsultarTiposRetencionesResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCtasCtesRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType">
+					</xsd:element>
+
+
+
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarObligadoRecepcionRequest" type="tns:consultarObligadoRecepcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarObligadoRecepcionResponse" type="tns:consultarObligadoRecepcionResponseType">
+			</xsd:element>
+			
+			<xsd:element name="consultarFacturasAgtDptoCltvRequest" type="tns:ConsultarFacturasAgtDptoCltvRequestType">
+			</xsd:element>
+			<xsd:element name="consultarFacturasAgtDptoCltvResponse" type="tns:ConsultarFacturasAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredResponse" type="tns:OperacionFECredResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredRequest" type="tns:InformarCancelacionTotalFECredRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCodigoDescripcionReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:element name="consultarTiposFormasCancelacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposFormasCancelacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+
+			<xsd:element name="aceptarFECredRequest" type="tns:AceptarFECredRequestType">
+			</xsd:element>
+			<xsd:element name="aceptarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="AceptarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayConfirmarNotasDC" type="tns:ArrayConfirmarNotasType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoCancelacion" type="tns:TipoCancelacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="saldoAceptado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+					</xsd:element>
+
+					<xsd:element name="informaCBU" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="CBUComprador" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			
+            <xsd:complexType name="IdCtaCteType">
+                <xsd:sequence>
+                    <xsd:choice maxOccurs="1" minOccurs="1">
+                        <xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType" />
+                    </xsd:choice>
+                </xsd:sequence>
+            </xsd:complexType>
+			
+            <xsd:group name="NewGroupDefinition">
+				<xsd:sequence />
+			</xsd:group>
+			<xsd:simpleType name="SiNoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:length value="1" />
+					<xsd:enumeration value="S" />
+					<xsd:enumeration value="N" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitEmisor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialEmi" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptovta" type="tns:PuntoVentaSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitReceptor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialRecep" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="tipoCodAuto" type="tns:TipoCodAutorizacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codAutorizacion" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaPuestaDispo" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenPago" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenAcep" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="importeTotal" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMoneda" type="xsd:decimal">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUEmisor" type="tns:CBUSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="AliasEmisor" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esAnulacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esPostAceptacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="idComprobanteAsociado" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="referenciasComerciales" type="tns:ArrayTexto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arraySubtotalesIVA" type="tns:ArraySubtotalesIVAType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayOtrosTributos" type="tns:ArrayOtrosTributosType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayItems" type="tns:ArrayItemsType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosGenerales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosComerciales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="leyendaComercial" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpType">
+					</xsd:element>
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoAcep" type="tns:TipoAceptacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaHoraAcep" type="xsd:dateTime">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="infoTransferencia" type="tns:InfoTransferenciaType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="ImporteSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="-9999999999999.99" />
+					<xsd:maxInclusive value="9999999999999.99" />
+					<xsd:totalDigits value="15" />
+					<xsd:fractionDigits value="2" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="DecimalSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="0" />
+					<xsd:maxInclusive value="999999999999.999999" />
+					<xsd:totalDigits value="18" />
+					<xsd:fractionDigits value="6" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		
+
+			<xsd:complexType name="ConsultarCodigoDescripcionRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="InformarCancelacionTotalFECredRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+				    <xsd:element maxOccurs="1" minOccurs="1" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="importeCancelacion" type="tns:ImporteSimpleType">
+				    </xsd:element>
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:complexType name="ConsultarCodigoDescripcionResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+				
+			
+			<xsd:element name="consultarCtasCtesRequest" type="tns:ConsultarCtasCtesRequestType">
+			</xsd:element>
+			<xsd:element name="consultarCtasCtesResponse" type="tns:ConsultarCtasCtesResponseType" />
+
+
+
+
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionStringReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+		
+			<xsd:simpleType name="TipoCodAutorizacionType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="E" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarTiposRetencionesReturn" type="tns:ConsultarTiposRetencionesReturnType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesReturnType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayTiposRetenciones" type="tns:ArrayTiposRetencionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayTiposRetencionesType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="tipoRetencion" type="tns:TipoRetencionType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="TipoRetencionType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="codigoJurisdiccion" type="xsd:short">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="descripcionJurisdiccion" type="xsd:string" />
+			        <xsd:element maxOccurs="1" minOccurs="1" name="porcentajeRetencion" type="tns:PorcentajeSimpleType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="PorcentajeSimpleType">
+			    <xsd:restriction base="xsd:decimal">
+			        <xsd:maxInclusive value="100.00" />
+			        <xsd:minInclusive value="0.0" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionRequestType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType" />
+
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarObligadoRecepcionReturn" type="tns:consultarObligadoRecepcionReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="respuesta" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="desde" type="xsd:date" />
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+
+		
+			<xsd:complexType name="consultarCuentasEnAgtDptoCltvResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarCuentasEnAgtDptoCltvReturn" type="tns:ConsultarCuentasEnAgtDptoCltvReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayCuentasEnAgente" type="tns:ArrayCuentasEnAgenteType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType" />
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			    	</xsd:element>
+			        
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayCuentasEnAgenteType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="cuentaEnAgente" type="tns:CuentaEnAgenteType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="CuentaEnAgenteType">
+			    <xsd:sequence>
+			    	<xsd:element name="cuitAgente" type="tns:CuitSimpleType" maxOccurs="1" minOccurs="1">
+			    	</xsd:element>
+			    	<xsd:element name="razonSocialAgente" type="xsd:string" maxOccurs="1" minOccurs="0" />
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="idCuenta" type="tns:IdCuentaAgenteSimpleType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="denominacion" type="tns:Texto250SimpleType">
+			    	</xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="CBUSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:length value="22" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+			
+			<xsd:simpleType name="IdCuentaAgenteSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:minLength value="3" />
+					<xsd:maxLength value="20" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="FiltroFechaType">
+				<xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="tipo" type="tns:TipoFechaSimpleType" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="desde" type="xsd:date" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="hasta" type="xsd:date" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoFechaSimpleType">
+				<xsd:annotation>
+					<xsd:documentation>
+						Campo que determina sobre que columna vamos a
+						hacer el filtro de fechas. Fechas posibles a
+						filtrar - fechaEmision - fechaPuestaDispo -
+						fechaVenPago - fechaVenAcep - fechaAcep -
+						fechaInfoAgDptoCltv
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:restriction base="xsd:string">
+
+
+
+					<xsd:enumeration value="Emision" />
+					<xsd:enumeration value="PuestaDispo" />
+					<xsd:enumeration value="VenPago" />
+					<xsd:enumeration value="VenAcep" />
+					<xsd:enumeration value="Acep" />
+					<xsd:enumeration value="InfoAgDptoCltv" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="RolSimpleType">
+				<xsd:restriction base="xsd:string">
+
+
+					<xsd:enumeration value="Emisor" />
+					<xsd:enumeration value="Receptor" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCmpSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="PendienteRecepcion" />
+					<xsd:enumeration value="Recepcionado" />
+					<xsd:enumeration value="Aceptado" />
+					<xsd:enumeration value="Rechazado" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCtaCteSimpleType">
+				<xsd:restriction base="xsd:string">
+
+					<xsd:enumeration value="Modificable" />
+					<xsd:enumeration value="Aceptada" />
+					<xsd:enumeration value="Rechazada" />
+					<xsd:enumeration value="CanceladaTotal" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="ArrayComprobantesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="comprobante" type="tns:ComprobanteType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoAceptacionSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="Tacita" />
+					<xsd:enumeration value="Expresa" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="IdComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="CUITEmisor" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptoVta" type="tns:PuntoVentaSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rechazarNotaDCReturn" type="tns:RechazarNotaDCReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCtasCtesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtasCtesReturn" type="tns:ConsultarCtasCtesReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtasCtesReturnType">
+            <xsd:sequence>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayInfosCtaCte" type="tns:ArrayInfosCtaCteType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	</xsd:element>
+            </xsd:sequence>
+
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayInfosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="infoCtaCte" type="tns:InfoCtaCteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFacturaCredito" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeTotalFC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string" />
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtaCteReturn" type="tns:ConsultarCtaCteReturnType">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="ctaCte" type="tns:CuentaCorrienteType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayConfirmarNotasType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="confirmarNota" type="tns:ConfirmarNotaDCType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConfirmarNotaDCType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="acepta" type="tns:SiNoSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idNota" type="tns:IdComprobanteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="CuentaCorrienteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="factura" type="tns:ComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayNotasDCAsociadas" type="tns:ArrayComprobantesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeInicial" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalNotasDC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+            		</xsd:element>
+
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayRetencionesType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="retencion" type="tns:RetencionType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="RetencionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codTipo" type="xsd:short" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="porcentaje" type="tns:PorcentajeSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="descMotivo" type="tns:Texto250SimpleType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="operacionFECredReturn" type="tns:OperacionFECredReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredReturnType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+        
+            <xsd:simpleType name="TipoCancelacionSimpleType">
+            	<xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="PAR" />
+            		<xsd:enumeration value="TOT" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InformarFacturaAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="idCtaCte" type="tns:IdCtaCteType" />
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="filtroFecha" type="tns:FiltroFechaType">
+            	    </xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarFacturasAgtDptoCltvReturn" type="tns:ConsultarFacturasAgtDptoCltvReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFacturasAgtDptoCltv" type="tns:ArrayFacturasAgtDptoCltvType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayFacturasAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="facturaInformada" type="tns:FacturaInformadaAgtDptoCltvType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="FacturaInformadaAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+	           	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="obtenerRemitosRequest" type="tns:ObtenerRemitosRequestType" />
+            <xsd:element name="obtenerRemitosResponse" type="tns:ObtenerRemitosResponseType">
+            </xsd:element>
+            <xsd:complexType name="ObtenerRemitosRequestType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosResponseType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="obtenerRemitosReturn" type="tns:ObtenerRemitosReturnType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosReturnType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayIdsRemitos" type="tns:ArrayIdsComprobantesType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayIdsComprobantesType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="1" name="idsComprobantes" type="tns:IdComprobanteType">
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArraySubtotalesIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="subtotalIVA" type="tns:SubtotalIVAType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="ArrayOtrosTributosType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="otroTributo" type="tns:OtroTributoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="SubtotalIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OtroTributoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="detalle" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayMotivosRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="motivoRechazo" type="tns:MotivoRechazoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="MotivoRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMotivo" type="xsd:short">
+					</xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="descMotivo" type="tns:Texto250SimpleType">
+					</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="justificacion" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="EstadoCmpType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosComprobanteRequest" type="tns:ConsultarHistorialEstadosComprobanteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosComprobanteResponse" type="tns:ConsultarHistorialEstadosComprobanteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+				    
+				</xsd:sequence>            
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosComprobanteReturn" type="tns:ConsultarHistorialEstadosComprobanteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosComprobanteType">
+            		</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayHistorialEstadosComprobanteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCmpType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosCtaCteRequest" type="tns:ConsultarHistorialEstadosCtaCteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosCtaCteResponse" type="tns:consultarHistorialEstadosCtaCteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosCtaCteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+				    
+				</xsd:sequence>  
+            </xsd:complexType>
+        
+            <xsd:complexType name="consultarHistorialEstadosCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosCtaCteReturn" type="tns:consultarHistorialEstadosCtaCteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="consultarHistorialEstadosCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayHistorialEstadosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="EstadoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCtaCteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayItemsType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="item" type="tns:ItemType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ItemType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="orden" type="xsd:int">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="unidadesMtx" type="xsd:int" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoMtx" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigo" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codNomMercosur" type="xsd:string" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="cantidad" type="tns:DecimalSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoUnidadMedida" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="precioUnitario" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeBonificacion" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigoCondicionIVA" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeIVA" type="tns:ImporteSimpleType">
+            		</xsd:element>
+
+                    <xsd:element maxOccurs="1" minOccurs="1" name="importeItem" type="tns:ImporteSimpleType">
+            		</xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayTexto250SimpleType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="texto" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarTiposAjustesOperacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarTiposAjustesOperacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+
+            </xsd:element>
+		
+            <xsd:complexType name="ArrayAjustesOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="ajuste" type="tns:AjusteOperacionType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="AjusteOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarMontoObligadoRecepcionRequest" type="tns:ConsultarMontoObligadoRecepcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarMontoObligadoRecepcionResponse" type="tns:ConsultarMontoObligadoRecepcionResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarMontoObligadoRecepcionReturn" type="tns:ConsultarMontoObligadoRecepcionReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionReturnType">
+            	<xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="obligado" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="montoDesde" type="tns:ImporteSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:simpleType name="OpcionTransferenciaSimpleType">
+                <xsd:annotation>
+                	<xsd:documentation>SCA - Sistema de Circulación Abierta
+ADC - Agente de Depósito Colectivo</xsd:documentation>
+                </xsd:annotation>
+                <xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="SCA" />
+            		<xsd:enumeration value="ADC" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InfoTransferenciaType">
+            	<xsd:sequence>
+            		<xsd:choice maxOccurs="1" minOccurs="1">
+            			<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            			<xsd:element name="infoSCA" type="tns:InfoSCAType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            		</xsd:choice>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaInfo" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="recibida" type="tns:SiNoSimpleType">
+            		</xsd:element>
+            		<xsd:element name="fechaLectura" type="xsd:date" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="fechaRecep" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="aceptada" type="tns:SiNoSimpleType" />
+            		<xsd:element name="motivoRechazo" type="xsd:string" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="idPagoAgtDptoCltv" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUAgtDptoCltv" type="tns:CBUSimpleType">
+					</xsd:element>
+            		
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="InfoSCAType">
+            	<xsd:sequence>
+            		<xsd:element name="fechaAceptacionFactura" type="xsd:date" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="informaCBUReceptor" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="CBUReceptor" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="CBUValidada" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="fechaLecturaSCA" type="xsd:dateTime" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaResponse" type="tns:OperacionFECredResponseType">
+
+            </xsd:element>
+
+            <xsd:complexType name="ModificarOpcionTransferenciaRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+            		</xsd:element>
+
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaRequest" type="tns:ModificarOpcionTransferenciaRequestType">
+            </xsd:element>
+		</xsd:schema>
+	</wsdl:types>
+
+
+	<wsdl:message name="dummyRequest" />
+
+	<wsdl:message name="dummyResponse">
+		<wsdl:part element="tns:dummyResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesRequest">
+		<wsdl:part element="tns:consultarComprobantesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesResponse">
+		<wsdl:part element="tns:consultarComprobantesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredRequest">
+		<wsdl:part element="tns:rechazarFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredResponse">
+		<wsdl:part element="tns:rechazarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteRequest">
+		<wsdl:part element="tns:consultarCtaCteRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteResponse">
+		<wsdl:part element="tns:consultarCtaCteResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCRequest">
+		<wsdl:part element="tns:rechazarNotaDCRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCResponse">
+		<wsdl:part element="tns:rechazarNotaDCResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvRequest">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvResponse">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteRequest">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteResponse">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesRequest">
+		<wsdl:part element="tns:consultarTiposRetencionesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesResponse">
+		<wsdl:part element="tns:consultarTiposRetencionesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvRequest">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvResponse">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredRequest">
+		<wsdl:part element="tns:informarCancelacionTotalFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredResponse">
+		<wsdl:part element="tns:informarCancelacionTotalFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+	<wsdl:message name="consultarTiposMotivosRechazoRequest">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposMotivosRechazoResponse">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionRequest">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionResponse">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="aceptarFECredRequest">
+		<wsdl:part element="tns:aceptarFECredRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="aceptarFECredResponse">
+		<wsdl:part element="tns:aceptarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+
+	<wsdl:message name="consultarCtasCtesRequest">
+		<wsdl:part element="tns:consultarCtasCtesRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarCtasCtesResponse">
+		<wsdl:part element="tns:consultarCtasCtesResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosRequest">
+	    <wsdl:part element="tns:obtenerRemitosRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosResponse">
+	    <wsdl:part element="tns:obtenerRemitosResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionRequest">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionResponse">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaRequest">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaRequest" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaResponse">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaResponse" />
+	</wsdl:message>
+	<wsdl:portType name="FECredServicePortType">
+
+		<wsdl:operation name="dummy">
+			<wsdl:documentation>Metodo dummy.</wsdl:documentation>
+			<wsdl:input message="tns:dummyRequest" />
+			<wsdl:output message="tns:dummyResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarComprobantes">
+			<wsdl:documentation>Método que permite obtener información sobre los comprobates Emitidos y Recibidos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarComprobantesRequest" />
+			<wsdl:output message="tns:consultarComprobantesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarNotaDC">
+			<wsdl:documentation>Método que permite al Comprador rechazar Notas de Débito / Crédito individualmente para
+				desafectarlas del cálculo del saldo de la Cta. Cte. vinculada.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarNotaDCRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:rechazarNotaDCResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtasCtes">
+			<wsdl:documentation>Método que permite obtener las cuentas corrientes que fueron generadas a partir de la
+				facturación, que coinciden con los parámetros de búsqueda.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtasCtesRequest" />
+			<wsdl:output message="tns:consultarCtasCtesResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtaCte">
+			<wsdl:documentation>Método que permite obtener el detalle y composición de una cuenta corriente.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaCteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaCteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<wsdl:documentation>Método por el cual el Comprador informa que le ha cancelado (pagado) totalmente la deuda al
+				vendedor, debiendo indicar la forma de pago.Solo puede cancelar las aceptadas dentros de los plazos establecidos
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarCancelacionTotalFECredRequest" />
+			<wsdl:output message="tns:informarCancelacionTotalFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="aceptarFECred">
+			<wsdl:documentation>Método que permite al Comprador Aceptar el saldo actual de la Cta. Cte. de una Factura de Crédito
+				pudiendo indicar: pagos parciales, retenciones y/o embargos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:aceptarFECredRequest" />
+			<wsdl:output message="tns:aceptarFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarFECred">
+			<wsdl:documentation>Método que permite al Comprador Rechazar la Cta. Cte. de una Factura de Crédito debiendo indicar
+				el motivo del rechazo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarFECredRequest" />
+			<wsdl:output message="tns:rechazarFECredResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor solicitar la transeferencia (al Agente de Depósito Colectivo) de
+				la factura de crédito con el saldo resultante de la cuenta corriente vinculada aceptada por el comprador, debiendo
+				indicar la Cuenta del Agente de Deposito Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarFacturaAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:informarFacturaAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<wsdl:documentation>Método que permite obtener información sobre las transeferencias realizadas al Agente de Depósito
+				Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarFacturasAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarFacturasAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor consultar sus cuentas en sus Agentes de Deposito Colectivo
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaAgenteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaAgenteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<wsdl:documentation>Método que permite a partir de una CUIT conocer su obligación respecto a la emisión o recepción
+				de facturas de créditos
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarObligadoRecepcionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarObligadoRecepcionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposRetenciones">
+			<wsdl:documentation>Método que permite consultar los tipos de retenciones habilitadas con sus respectivos porcentajes.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposRetencionesRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposRetencionesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<wsdl:documentation>Método que permite listar los tipos de  motivos de rechazo habilitados para una cta. cte.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposMotivosRechazoRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposMotivosRechazoResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<wsdl:documentation>Método que permite listar los tipos de formas de pago habilitados para una factura de crédito.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposFormasCancelacionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposFormasCancelacionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+		    <wsdl:input message="tns:obtenerRemitosRequest" />
+		    <wsdl:output message="tns:obtenerRemitosResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<wsdl:input message="tns:consultarHistorialEstadosComprobanteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosComprobanteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<wsdl:input message="tns:consultarHistorialEstadosCtaCteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosCtaCteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<wsdl:input message="tns:consultarTiposAjustesOperacionRequest" />
+			<wsdl:output message="tns:consultarTiposAjustesOperacionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<wsdl:input message="tns:consultarMontoObligadoRecepcionRequest" />
+			<wsdl:output message="tns:consultarMontoObligadoRecepcionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<wsdl:input message="tns:modificarOpcionTransferenciaRequest" />
+			<wsdl:output message="tns:modificarOpcionTransferenciaResponse" />
+		</wsdl:operation>
+	</wsdl:portType>
+
+
+	<wsdl:binding name="FECredServiceSOAP" type="tns:FECredServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="dummy">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/dummy" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarComprobantes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarComprobantes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtasCtes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtasCtes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarNotaDC">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarNotaDC" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarFacturaAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposRetenciones">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposRetenciones" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarFacturasAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarCancelacionTotalFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposMotivosRechazo" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposFormasCancelacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="aceptarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/aceptarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCuentasEnAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/obtenerRemitos" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosComprobante" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposAjustesOperacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarMontoObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/modificarOpcionTransferencia" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="FECredService">
+		<wsdl:port binding="tns:FECredServiceSOAP" name="FECredServiceSOAP">
+			<soap:address location="https://serviciosjava.afip.gob.ar:443/wsfecred/FECredService" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>`,
+  'wsfecred.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://ar.gob.afip.wsfecred/FECredService/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="FECredService" targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+			<xsd:element name="dummyResponse" type="tns:DummyResponseType" />
+			<xsd:complexType name="DummyResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="dummyReturn" type="tns:DummyReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="DummyReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="appserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="authserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="dbserver" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="AuthRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="token" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="sign" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitRepresentada" type="tns:CuitSimpleType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="CuitSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minExclusive value="9999999999" />
+					<xsd:maxInclusive value="99999999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ArrayCodigosDescripcionesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcion" type="tns:CodigoDescripcionType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ArrayCodigosDescripcionesStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcionString" type="tns:CodigoDescripcionStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+
+
+			<xsd:element name="consultarComprobantesRequest" type="tns:ConsultarComprobanteRequestType" />
+			<xsd:element name="consultarComprobantesResponse" type="tns:ConsultarComprobantesResponseType" />
+			<xsd:complexType name="ConsultarComprobanteRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCmp" type="tns:EstadoCmpSimpleType" />
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType" />
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="codCtaCte" type="xsd:long" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarComprobantesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCmpReturn" type="tns:ConsultarCmpReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarCmpReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayComprobantes" type="tns:ArrayComprobantesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+	            	</xsd:element>
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:simpleType name="ResultadoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="O" />
+					<xsd:enumeration value="R" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="NumeroComprobanteSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="PuntoVentaSimpleType">
+				<xsd:restriction base="xsd:int">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:element name="rechazarFECredRequest" type="tns:RechazarFECredRequestType" />
+			<xsd:element name="rechazarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="RechazarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarCtaCteRequest" type="tns:ConsultarCtaCteRequestType" />
+			<xsd:element name="consultarCtaCteResponse" type="tns:ConsultarCtaCteResponseType" />
+			<xsd:complexType name="ConsultarCtaCteRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:element name="rechazarNotaDCRequest" type="tns:RechazarNotaDCRequestType">
+			</xsd:element>
+			<xsd:element name="rechazarNotaDCResponse" type="tns:RechazarNotaDCResponseType" />
+			<xsd:complexType name="RechazarNotaDCRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="informarFacturaAgtDptoCltvRequest" type="tns:InformarFacturaAgtDptoCltvRequestType" />
+			<xsd:element name="informarFacturaAgtDptoCltvResponse" type="tns:OperacionFECredResponseType" />
+			
+			<xsd:element name="consultarCuentasEnAgtDptoCltvRequest" type="tns:ConsultarCuentasEnAgtDptoCltvRequestType" />
+			<xsd:element name="consultarCuentasEnAgtDptoCltvResponse" type="tns:consultarCuentasEnAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="Texto250SimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="3" />
+					<xsd:maxLength value="250" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+
+
+			<xsd:element name="consultarTiposRetencionesRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposRetencionesResponse" type="tns:ConsultarTiposRetencionesResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCtasCtesRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType">
+					</xsd:element>
+
+
+
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarObligadoRecepcionRequest" type="tns:consultarObligadoRecepcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarObligadoRecepcionResponse" type="tns:consultarObligadoRecepcionResponseType">
+			</xsd:element>
+			
+			<xsd:element name="consultarFacturasAgtDptoCltvRequest" type="tns:ConsultarFacturasAgtDptoCltvRequestType">
+			</xsd:element>
+			<xsd:element name="consultarFacturasAgtDptoCltvResponse" type="tns:ConsultarFacturasAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredResponse" type="tns:OperacionFECredResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredRequest" type="tns:InformarCancelacionTotalFECredRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCodigoDescripcionReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:element name="consultarTiposFormasCancelacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposFormasCancelacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+
+			<xsd:element name="aceptarFECredRequest" type="tns:AceptarFECredRequestType">
+			</xsd:element>
+			<xsd:element name="aceptarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="AceptarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayConfirmarNotasDC" type="tns:ArrayConfirmarNotasType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoCancelacion" type="tns:TipoCancelacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="saldoAceptado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+					</xsd:element>
+
+					<xsd:element name="informaCBU" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="CBUComprador" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			
+            <xsd:complexType name="IdCtaCteType">
+                <xsd:sequence>
+                    <xsd:choice maxOccurs="1" minOccurs="1">
+                        <xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType" />
+                    </xsd:choice>
+                </xsd:sequence>
+            </xsd:complexType>
+			
+            <xsd:group name="NewGroupDefinition">
+				<xsd:sequence />
+			</xsd:group>
+			<xsd:simpleType name="SiNoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:length value="1" />
+					<xsd:enumeration value="S" />
+					<xsd:enumeration value="N" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitEmisor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialEmi" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptovta" type="tns:PuntoVentaSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitReceptor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialRecep" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="tipoCodAuto" type="tns:TipoCodAutorizacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codAutorizacion" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaPuestaDispo" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenPago" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenAcep" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="importeTotal" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMoneda" type="xsd:decimal">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUEmisor" type="tns:CBUSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="AliasEmisor" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esAnulacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esPostAceptacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="idComprobanteAsociado" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="referenciasComerciales" type="tns:ArrayTexto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arraySubtotalesIVA" type="tns:ArraySubtotalesIVAType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayOtrosTributos" type="tns:ArrayOtrosTributosType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayItems" type="tns:ArrayItemsType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosGenerales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosComerciales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="leyendaComercial" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpType">
+					</xsd:element>
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoAcep" type="tns:TipoAceptacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaHoraAcep" type="xsd:dateTime">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="infoTransferencia" type="tns:InfoTransferenciaType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="ImporteSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="-9999999999999.99" />
+					<xsd:maxInclusive value="9999999999999.99" />
+					<xsd:totalDigits value="15" />
+					<xsd:fractionDigits value="2" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="DecimalSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="0" />
+					<xsd:maxInclusive value="999999999999.999999" />
+					<xsd:totalDigits value="18" />
+					<xsd:fractionDigits value="6" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		
+
+			<xsd:complexType name="ConsultarCodigoDescripcionRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="InformarCancelacionTotalFECredRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+				    <xsd:element maxOccurs="1" minOccurs="1" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="importeCancelacion" type="tns:ImporteSimpleType">
+				    </xsd:element>
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:complexType name="ConsultarCodigoDescripcionResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+				
+			
+			<xsd:element name="consultarCtasCtesRequest" type="tns:ConsultarCtasCtesRequestType">
+			</xsd:element>
+			<xsd:element name="consultarCtasCtesResponse" type="tns:ConsultarCtasCtesResponseType" />
+
+
+
+
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionStringReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+		
+			<xsd:simpleType name="TipoCodAutorizacionType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="E" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarTiposRetencionesReturn" type="tns:ConsultarTiposRetencionesReturnType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesReturnType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayTiposRetenciones" type="tns:ArrayTiposRetencionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayTiposRetencionesType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="tipoRetencion" type="tns:TipoRetencionType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="TipoRetencionType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="codigoJurisdiccion" type="xsd:short">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="descripcionJurisdiccion" type="xsd:string" />
+			        <xsd:element maxOccurs="1" minOccurs="1" name="porcentajeRetencion" type="tns:PorcentajeSimpleType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="PorcentajeSimpleType">
+			    <xsd:restriction base="xsd:decimal">
+			        <xsd:maxInclusive value="100.00" />
+			        <xsd:minInclusive value="0.0" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionRequestType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType" />
+
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarObligadoRecepcionReturn" type="tns:consultarObligadoRecepcionReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="respuesta" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="desde" type="xsd:date" />
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+
+		
+			<xsd:complexType name="consultarCuentasEnAgtDptoCltvResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarCuentasEnAgtDptoCltvReturn" type="tns:ConsultarCuentasEnAgtDptoCltvReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayCuentasEnAgente" type="tns:ArrayCuentasEnAgenteType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType" />
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			    	</xsd:element>
+			        
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayCuentasEnAgenteType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="cuentaEnAgente" type="tns:CuentaEnAgenteType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="CuentaEnAgenteType">
+			    <xsd:sequence>
+			    	<xsd:element name="cuitAgente" type="tns:CuitSimpleType" maxOccurs="1" minOccurs="1">
+			    	</xsd:element>
+			    	<xsd:element name="razonSocialAgente" type="xsd:string" maxOccurs="1" minOccurs="0" />
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="idCuenta" type="tns:IdCuentaAgenteSimpleType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="denominacion" type="tns:Texto250SimpleType">
+			    	</xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="CBUSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:length value="22" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+			
+			<xsd:simpleType name="IdCuentaAgenteSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:minLength value="3" />
+					<xsd:maxLength value="20" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="FiltroFechaType">
+				<xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="tipo" type="tns:TipoFechaSimpleType" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="desde" type="xsd:date" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="hasta" type="xsd:date" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoFechaSimpleType">
+				<xsd:annotation>
+					<xsd:documentation>
+						Campo que determina sobre que columna vamos a
+						hacer el filtro de fechas. Fechas posibles a
+						filtrar - fechaEmision - fechaPuestaDispo -
+						fechaVenPago - fechaVenAcep - fechaAcep -
+						fechaInfoAgDptoCltv
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:restriction base="xsd:string">
+
+
+
+					<xsd:enumeration value="Emision" />
+					<xsd:enumeration value="PuestaDispo" />
+					<xsd:enumeration value="VenPago" />
+					<xsd:enumeration value="VenAcep" />
+					<xsd:enumeration value="Acep" />
+					<xsd:enumeration value="InfoAgDptoCltv" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="RolSimpleType">
+				<xsd:restriction base="xsd:string">
+
+
+					<xsd:enumeration value="Emisor" />
+					<xsd:enumeration value="Receptor" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCmpSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="PendienteRecepcion" />
+					<xsd:enumeration value="Recepcionado" />
+					<xsd:enumeration value="Aceptado" />
+					<xsd:enumeration value="Rechazado" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCtaCteSimpleType">
+				<xsd:restriction base="xsd:string">
+
+					<xsd:enumeration value="Modificable" />
+					<xsd:enumeration value="Aceptada" />
+					<xsd:enumeration value="Rechazada" />
+					<xsd:enumeration value="CanceladaTotal" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="ArrayComprobantesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="comprobante" type="tns:ComprobanteType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoAceptacionSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="Tacita" />
+					<xsd:enumeration value="Expresa" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="IdComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="CUITEmisor" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptoVta" type="tns:PuntoVentaSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rechazarNotaDCReturn" type="tns:RechazarNotaDCReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCtasCtesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtasCtesReturn" type="tns:ConsultarCtasCtesReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtasCtesReturnType">
+            <xsd:sequence>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayInfosCtaCte" type="tns:ArrayInfosCtaCteType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	</xsd:element>
+            </xsd:sequence>
+
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayInfosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="infoCtaCte" type="tns:InfoCtaCteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFacturaCredito" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeTotalFC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string" />
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtaCteReturn" type="tns:ConsultarCtaCteReturnType">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="ctaCte" type="tns:CuentaCorrienteType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayConfirmarNotasType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="confirmarNota" type="tns:ConfirmarNotaDCType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConfirmarNotaDCType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="acepta" type="tns:SiNoSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idNota" type="tns:IdComprobanteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="CuentaCorrienteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="factura" type="tns:ComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayNotasDCAsociadas" type="tns:ArrayComprobantesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeInicial" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalNotasDC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+            		</xsd:element>
+
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayRetencionesType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="retencion" type="tns:RetencionType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="RetencionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codTipo" type="xsd:short" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="porcentaje" type="tns:PorcentajeSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="descMotivo" type="tns:Texto250SimpleType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="operacionFECredReturn" type="tns:OperacionFECredReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredReturnType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+        
+            <xsd:simpleType name="TipoCancelacionSimpleType">
+            	<xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="PAR" />
+            		<xsd:enumeration value="TOT" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InformarFacturaAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="idCtaCte" type="tns:IdCtaCteType" />
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="filtroFecha" type="tns:FiltroFechaType">
+            	    </xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarFacturasAgtDptoCltvReturn" type="tns:ConsultarFacturasAgtDptoCltvReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFacturasAgtDptoCltv" type="tns:ArrayFacturasAgtDptoCltvType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayFacturasAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="facturaInformada" type="tns:FacturaInformadaAgtDptoCltvType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="FacturaInformadaAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+	           	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="obtenerRemitosRequest" type="tns:ObtenerRemitosRequestType" />
+            <xsd:element name="obtenerRemitosResponse" type="tns:ObtenerRemitosResponseType">
+            </xsd:element>
+            <xsd:complexType name="ObtenerRemitosRequestType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosResponseType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="obtenerRemitosReturn" type="tns:ObtenerRemitosReturnType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosReturnType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayIdsRemitos" type="tns:ArrayIdsComprobantesType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayIdsComprobantesType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="1" name="idsComprobantes" type="tns:IdComprobanteType">
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArraySubtotalesIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="subtotalIVA" type="tns:SubtotalIVAType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="ArrayOtrosTributosType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="otroTributo" type="tns:OtroTributoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="SubtotalIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OtroTributoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="detalle" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayMotivosRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="motivoRechazo" type="tns:MotivoRechazoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="MotivoRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMotivo" type="xsd:short">
+					</xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="descMotivo" type="tns:Texto250SimpleType">
+					</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="justificacion" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="EstadoCmpType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosComprobanteRequest" type="tns:ConsultarHistorialEstadosComprobanteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosComprobanteResponse" type="tns:ConsultarHistorialEstadosComprobanteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+				    
+				</xsd:sequence>            
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosComprobanteReturn" type="tns:ConsultarHistorialEstadosComprobanteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosComprobanteType">
+            		</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayHistorialEstadosComprobanteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCmpType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosCtaCteRequest" type="tns:ConsultarHistorialEstadosCtaCteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosCtaCteResponse" type="tns:consultarHistorialEstadosCtaCteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosCtaCteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+				    
+				</xsd:sequence>  
+            </xsd:complexType>
+        
+            <xsd:complexType name="consultarHistorialEstadosCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosCtaCteReturn" type="tns:consultarHistorialEstadosCtaCteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="consultarHistorialEstadosCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayHistorialEstadosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="EstadoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCtaCteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayItemsType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="item" type="tns:ItemType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ItemType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="orden" type="xsd:int">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="unidadesMtx" type="xsd:int" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoMtx" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigo" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codNomMercosur" type="xsd:string" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="cantidad" type="tns:DecimalSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoUnidadMedida" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="precioUnitario" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeBonificacion" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigoCondicionIVA" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeIVA" type="tns:ImporteSimpleType">
+            		</xsd:element>
+
+                    <xsd:element maxOccurs="1" minOccurs="1" name="importeItem" type="tns:ImporteSimpleType">
+            		</xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayTexto250SimpleType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="texto" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarTiposAjustesOperacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarTiposAjustesOperacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+
+            </xsd:element>
+		
+            <xsd:complexType name="ArrayAjustesOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="ajuste" type="tns:AjusteOperacionType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="AjusteOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarMontoObligadoRecepcionRequest" type="tns:ConsultarMontoObligadoRecepcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarMontoObligadoRecepcionResponse" type="tns:ConsultarMontoObligadoRecepcionResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarMontoObligadoRecepcionReturn" type="tns:ConsultarMontoObligadoRecepcionReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionReturnType">
+            	<xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="obligado" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="montoDesde" type="tns:ImporteSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:simpleType name="OpcionTransferenciaSimpleType">
+                <xsd:annotation>
+                	<xsd:documentation>SCA - Sistema de Circulación Abierta
+ADC - Agente de Depósito Colectivo</xsd:documentation>
+                </xsd:annotation>
+                <xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="SCA" />
+            		<xsd:enumeration value="ADC" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InfoTransferenciaType">
+            	<xsd:sequence>
+            		<xsd:choice maxOccurs="1" minOccurs="1">
+            			<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            			<xsd:element name="infoSCA" type="tns:InfoSCAType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            		</xsd:choice>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaInfo" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="recibida" type="tns:SiNoSimpleType">
+            		</xsd:element>
+            		<xsd:element name="fechaLectura" type="xsd:date" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="fechaRecep" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="aceptada" type="tns:SiNoSimpleType" />
+            		<xsd:element name="motivoRechazo" type="xsd:string" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="idPagoAgtDptoCltv" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUAgtDptoCltv" type="tns:CBUSimpleType">
+					</xsd:element>
+            		
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="InfoSCAType">
+            	<xsd:sequence>
+            		<xsd:element name="fechaAceptacionFactura" type="xsd:date" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="informaCBUReceptor" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="CBUReceptor" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="CBUValidada" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="fechaLecturaSCA" type="xsd:dateTime" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaResponse" type="tns:OperacionFECredResponseType">
+
+            </xsd:element>
+
+            <xsd:complexType name="ModificarOpcionTransferenciaRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+            		</xsd:element>
+
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaRequest" type="tns:ModificarOpcionTransferenciaRequestType">
+            </xsd:element>
+		</xsd:schema>
+	</wsdl:types>
+
+
+	<wsdl:message name="dummyRequest" />
+
+	<wsdl:message name="dummyResponse">
+		<wsdl:part element="tns:dummyResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesRequest">
+		<wsdl:part element="tns:consultarComprobantesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesResponse">
+		<wsdl:part element="tns:consultarComprobantesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredRequest">
+		<wsdl:part element="tns:rechazarFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredResponse">
+		<wsdl:part element="tns:rechazarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteRequest">
+		<wsdl:part element="tns:consultarCtaCteRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteResponse">
+		<wsdl:part element="tns:consultarCtaCteResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCRequest">
+		<wsdl:part element="tns:rechazarNotaDCRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCResponse">
+		<wsdl:part element="tns:rechazarNotaDCResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvRequest">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvResponse">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteRequest">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteResponse">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesRequest">
+		<wsdl:part element="tns:consultarTiposRetencionesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesResponse">
+		<wsdl:part element="tns:consultarTiposRetencionesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvRequest">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvResponse">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredRequest">
+		<wsdl:part element="tns:informarCancelacionTotalFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredResponse">
+		<wsdl:part element="tns:informarCancelacionTotalFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+	<wsdl:message name="consultarTiposMotivosRechazoRequest">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposMotivosRechazoResponse">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionRequest">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionResponse">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="aceptarFECredRequest">
+		<wsdl:part element="tns:aceptarFECredRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="aceptarFECredResponse">
+		<wsdl:part element="tns:aceptarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+
+	<wsdl:message name="consultarCtasCtesRequest">
+		<wsdl:part element="tns:consultarCtasCtesRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarCtasCtesResponse">
+		<wsdl:part element="tns:consultarCtasCtesResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosRequest">
+	    <wsdl:part element="tns:obtenerRemitosRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosResponse">
+	    <wsdl:part element="tns:obtenerRemitosResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionRequest">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionResponse">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaRequest">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaRequest" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaResponse">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaResponse" />
+	</wsdl:message>
+	<wsdl:portType name="FECredServicePortType">
+
+		<wsdl:operation name="dummy">
+			<wsdl:documentation>Metodo dummy.</wsdl:documentation>
+			<wsdl:input message="tns:dummyRequest" />
+			<wsdl:output message="tns:dummyResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarComprobantes">
+			<wsdl:documentation>Método que permite obtener información sobre los comprobates Emitidos y Recibidos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarComprobantesRequest" />
+			<wsdl:output message="tns:consultarComprobantesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarNotaDC">
+			<wsdl:documentation>Método que permite al Comprador rechazar Notas de Débito / Crédito individualmente para
+				desafectarlas del cálculo del saldo de la Cta. Cte. vinculada.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarNotaDCRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:rechazarNotaDCResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtasCtes">
+			<wsdl:documentation>Método que permite obtener las cuentas corrientes que fueron generadas a partir de la
+				facturación, que coinciden con los parámetros de búsqueda.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtasCtesRequest" />
+			<wsdl:output message="tns:consultarCtasCtesResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtaCte">
+			<wsdl:documentation>Método que permite obtener el detalle y composición de una cuenta corriente.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaCteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaCteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<wsdl:documentation>Método por el cual el Comprador informa que le ha cancelado (pagado) totalmente la deuda al
+				vendedor, debiendo indicar la forma de pago.Solo puede cancelar las aceptadas dentros de los plazos establecidos
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarCancelacionTotalFECredRequest" />
+			<wsdl:output message="tns:informarCancelacionTotalFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="aceptarFECred">
+			<wsdl:documentation>Método que permite al Comprador Aceptar el saldo actual de la Cta. Cte. de una Factura de Crédito
+				pudiendo indicar: pagos parciales, retenciones y/o embargos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:aceptarFECredRequest" />
+			<wsdl:output message="tns:aceptarFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarFECred">
+			<wsdl:documentation>Método que permite al Comprador Rechazar la Cta. Cte. de una Factura de Crédito debiendo indicar
+				el motivo del rechazo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarFECredRequest" />
+			<wsdl:output message="tns:rechazarFECredResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor solicitar la transeferencia (al Agente de Depósito Colectivo) de
+				la factura de crédito con el saldo resultante de la cuenta corriente vinculada aceptada por el comprador, debiendo
+				indicar la Cuenta del Agente de Deposito Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarFacturaAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:informarFacturaAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<wsdl:documentation>Método que permite obtener información sobre las transeferencias realizadas al Agente de Depósito
+				Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarFacturasAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarFacturasAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor consultar sus cuentas en sus Agentes de Deposito Colectivo
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaAgenteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaAgenteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<wsdl:documentation>Método que permite a partir de una CUIT conocer su obligación respecto a la emisión o recepción
+				de facturas de créditos
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarObligadoRecepcionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarObligadoRecepcionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposRetenciones">
+			<wsdl:documentation>Método que permite consultar los tipos de retenciones habilitadas con sus respectivos porcentajes.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposRetencionesRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposRetencionesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<wsdl:documentation>Método que permite listar los tipos de  motivos de rechazo habilitados para una cta. cte.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposMotivosRechazoRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposMotivosRechazoResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<wsdl:documentation>Método que permite listar los tipos de formas de pago habilitados para una factura de crédito.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposFormasCancelacionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposFormasCancelacionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+		    <wsdl:input message="tns:obtenerRemitosRequest" />
+		    <wsdl:output message="tns:obtenerRemitosResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<wsdl:input message="tns:consultarHistorialEstadosComprobanteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosComprobanteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<wsdl:input message="tns:consultarHistorialEstadosCtaCteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosCtaCteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<wsdl:input message="tns:consultarTiposAjustesOperacionRequest" />
+			<wsdl:output message="tns:consultarTiposAjustesOperacionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<wsdl:input message="tns:consultarMontoObligadoRecepcionRequest" />
+			<wsdl:output message="tns:consultarMontoObligadoRecepcionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<wsdl:input message="tns:modificarOpcionTransferenciaRequest" />
+			<wsdl:output message="tns:modificarOpcionTransferenciaResponse" />
+		</wsdl:operation>
+	</wsdl:portType>
+
+
+	<wsdl:binding name="FECredServiceSOAP" type="tns:FECredServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="dummy">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/dummy" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarComprobantes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarComprobantes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtasCtes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtasCtes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarNotaDC">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarNotaDC" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarFacturaAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposRetenciones">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposRetenciones" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarFacturasAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarCancelacionTotalFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposMotivosRechazo" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposFormasCancelacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="aceptarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/aceptarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCuentasEnAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/obtenerRemitos" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosComprobante" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposAjustesOperacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarMontoObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/modificarOpcionTransferencia" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="FECredService">
+		<wsdl:port binding="tns:FECredServiceSOAP" name="FECredServiceSOAP">
+			<soap:address location="https://fwshomo.afip.gov.ar:443/wsfecred/FECredService" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>`,
+  'wsfex-production.wsdl': `<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://ar.gov.afip.dif.fexv1/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://ar.gov.afip.dif.fexv1/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://ar.gov.afip.dif.fexv1/">
+      <s:element name="FEXAuthorize">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXAuthRequest">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXRequest">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Permiso" nillable="true" type="tns:Permiso" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Permiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id_permiso" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfCmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Cmp_asoc" nillable="true" type="tns:Cmp_asoc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Cmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfItem">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Item" nillable="true" type="tns:Item" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Item">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_qty" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_umed" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_precio_uni" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_bonificacion" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_total_item" type="s:decimal" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfOpcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Opcional" nillable="true" type="tns:Opcional" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Opcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Valor" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfActividad">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Actividad" nillable="true" type="tns:Actividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Actividad">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXAuthorizeResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXAuthorizeResult" type="tns:FEXResponseAuthorize" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseAuthorize">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultAuth" type="tns:ClsFEXOutAuthorize" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXOutAuthorize">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_cbte" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Reproceso" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXErr">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="ErrCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="ErrMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXEvents">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="EventCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="EventMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXGetCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXGetCMP">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetCMPResult" type="tns:FEXGetCMPResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXGetCMPResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXGetCMPR" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXGetCMPR">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte_cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Cbte_Tipo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Cbte_TipoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Cbte_TipoResult" type="tns:FEXResponse_Cbte_Tipo" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Cbte_Tipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Cbte_Tipo" nillable="true" type="tns:ClsFEXResponse_Cbte_Tipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Tipo_Expo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Tipo_ExpoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Tipo_ExpoResult" type="tns:FEXResponse_Tex" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Tex" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Tex" nillable="true" type="tns:ClsFEXResponse_Tex" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Tex_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Incoterms">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IncotermsResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IncotermsResult" type="tns:FEXResponse_Inc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Inc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Inc" nillable="true" type="tns:ClsFEXResponse_Inc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Idiomas">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IdiomasResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IdiomasResult" type="tns:FEXResponse_Idi" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Idi" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Idi" nillable="true" type="tns:ClsFEXResponse_Idi" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Idi_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_UMed">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_UMedResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_UMedResult" type="tns:FEXResponse_Umed" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Umed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_UMed" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_UMed" nillable="true" type="tns:ClsFEXResponse_UMed" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Umed_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_pais">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_paisResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_paisResult" type="tns:FEXResponse_DST_pais" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_pais" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_pais" nillable="true" type="tns:ClsFEXResponse_DST_pais" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_CUIT">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_CUITResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_CUITResult" type="tns:FEXResponse_DST_cuit" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_cuit" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_cuit" nillable="true" type="tns:ClsFEXResponse_DST_cuit" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="DST_CUIT" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MONResult" type="tns:FEXResponse_Mon" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon" nillable="true" type="tns:ClsFEXResponse_Mon" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACION">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Fecha_CTZ" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACIONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MON_CON_COTIZACIONResult" type="tns:FEXResponse_Mon_CON_COTIZACION" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon_CON_COTIZACION">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon_CON_Cotizacion" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon_CON_Cotizacion" nillable="true" type="tns:ClsFEXResponse_Mon_CON_Cotizacion" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_ctz" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_ctz" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEX_LastCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEX_LastCMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pto_venta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_CMPResult" type="tns:FEXResponseLast_CMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseLast_CMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResult_LastCMP" type="tns:ClsFEX_LastCMP_Response" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEX_LastCMP_Response">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXDummy">
+        <s:complexType />
+      </s:element>
+      <s:element name="FEXDummyResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXDummyResult" type="tns:DummyResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="DummyResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="AppServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DbServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="AuthServer" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Ctz">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Mon_id" type="s:string" />
+            <s:element minOccurs="0" maxOccurs="1" name="FchCotiz" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_CtzResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_CtzResult" type="tns:FEXResponse_Ctz" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_Ctz" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Mon_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_ID">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetLast_IDResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_IDResult" type="tns:FEXResponse_LastID" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_LastID" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_PtoVenta">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_PtoVentaResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_PtoVentaResult" type="tns:FEXResponse_PtoVenta" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_PtoVenta" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_PtoVenta" nillable="true" type="tns:ClsFEXResponse_PtoVenta" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Pve_Nro" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_Bloqueado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_FchBaja" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXCheck_Permiso">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="ID_Permiso" type="s:string" />
+            <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXCheck_PermisoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXCheck_PermisoResult" type="tns:FEXResponse_CheckPermiso" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_CheckPermiso" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Status" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Opcionales">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_OpcionalesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_OpcionalesResult" type="tns:FEXResponse_Opc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Opc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Opc" nillable="true" type="tns:ClsFEXResponse_Opc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Opc_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Actividades">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_ActividadesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_ActividadesResult" type="tns:FEXResponse_Actividades" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Actividades">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_ActividadTipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_ActividadTipo" nillable="true" type="tns:ClsFEXResponse_ActividadTipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Orden" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Desc" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="FEXAuthorizeSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXAuthorize" />
+  </wsdl:message>
+  <wsdl:message name="FEXAuthorizeSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXAuthorizeResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetCMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetCMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_Tipo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_TipoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_Expo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_ExpoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Incoterms" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IncotermsResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Idiomas" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IdiomasResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMed" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMedResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_pais" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_paisResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUIT" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUITResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACION" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACIONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapIn">
+    <wsdl:part name="parameters" element="tns:FEXDummy" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapOut">
+    <wsdl:part name="parameters" element="tns:FEXDummyResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Ctz" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_CtzResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_ID" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_IDResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVenta" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVentaResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXCheck_Permiso" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXCheck_PermisoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Opcionales" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_OpcionalesResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Actividades" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_ActividadesResponse" />
+  </wsdl:message>
+  <wsdl:portType name="ServiceSoap">
+    <wsdl:operation name="FEXAuthorize">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Autoriza un comprobante, devolviendo  su CAE correspondiente</wsdl:documentation>
+      <wsdl:input message="tns:FEXAuthorizeSoapIn" />
+      <wsdl:output message="tns:FEXAuthorizeSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera los datos completos de un comprobante ya autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetCMPSoapIn" />
+      <wsdl:output message="tns:FEXGetCMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de comprobante  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Cbte_TipoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Cbte_TipoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de exportacion  y sus codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Tipo_ExpoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Tipo_ExpoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado Incoterms  utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IncotermsSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IncotermsSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los idiomas  y sus codigos utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IdiomasSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IdiomasSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las unidades de medida  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_UMedSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_UMedSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de paises</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_paisSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_paisSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las cuits de los paises de destinacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_CUITSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_CUITSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas que tengan cotizacion de ADUANA a una fecha determinada, utilizables en el proceso de autorizacion de comprobantes de servicios</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimos comprobante autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_CMPSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_CMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Metodo dummy para verificacion de funcionamiento</wsdl:documentation>
+      <wsdl:input message="tns:FEXDummySoapIn" />
+      <wsdl:output message="tns:FEXDummySoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera la cotizacion de la moneda consultada y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_CtzSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_CtzSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimo ID y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_IDSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_IDSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los puntos de venta registrados para Factura electronica de exportacion - WS y su estado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_PtoVentaSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_PtoVentaSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifica la  existencia de la permiso/pais de destinación  de embarque ingresado</wsdl:documentation>
+      <wsdl:input message="tns:FEXCheck_PermisoSoapIn" />
+      <wsdl:output message="tns:FEXCheck_PermisoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de identificadores para los campos Opcionales</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_OpcionalesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_OpcionalesSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las diferentes actividades habilitadas para el emisor</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_ActividadesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_ActividadesSoapOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="ServiceSoap" type="tns:ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="ServiceSoap12" type="tns:ServiceSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Service">
+    <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+    <wsdl:port name="ServiceSoap" binding="tns:ServiceSoap">
+      <soap:address location="https://servicios1.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+    <wsdl:port name="ServiceSoap12" binding="tns:ServiceSoap12">
+      <soap12:address location="https://servicios1.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'wsfex.wsdl': `<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://ar.gov.afip.dif.fexv1/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://ar.gov.afip.dif.fexv1/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://ar.gov.afip.dif.fexv1/">
+      <s:element name="FEXAuthorize">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXAuthRequest">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXRequest">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Permiso" nillable="true" type="tns:Permiso" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Permiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id_permiso" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfCmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Cmp_asoc" nillable="true" type="tns:Cmp_asoc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Cmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfItem">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Item" nillable="true" type="tns:Item" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Item">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_qty" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_umed" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_precio_uni" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_bonificacion" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_total_item" type="s:decimal" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfOpcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Opcional" nillable="true" type="tns:Opcional" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Opcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Valor" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfActividad">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Actividad" nillable="true" type="tns:Actividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Actividad">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXAuthorizeResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXAuthorizeResult" type="tns:FEXResponseAuthorize" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseAuthorize">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultAuth" type="tns:ClsFEXOutAuthorize" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXOutAuthorize">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_cbte" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Reproceso" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXErr">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="ErrCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="ErrMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXEvents">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="EventCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="EventMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXGetCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXGetCMP">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetCMPResult" type="tns:FEXGetCMPResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXGetCMPResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXGetCMPR" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXGetCMPR">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte_cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Cbte_Tipo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Cbte_TipoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Cbte_TipoResult" type="tns:FEXResponse_Cbte_Tipo" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Cbte_Tipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Cbte_Tipo" nillable="true" type="tns:ClsFEXResponse_Cbte_Tipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Tipo_Expo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Tipo_ExpoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Tipo_ExpoResult" type="tns:FEXResponse_Tex" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Tex" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Tex" nillable="true" type="tns:ClsFEXResponse_Tex" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Tex_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Incoterms">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IncotermsResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IncotermsResult" type="tns:FEXResponse_Inc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Inc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Inc" nillable="true" type="tns:ClsFEXResponse_Inc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Idiomas">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IdiomasResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IdiomasResult" type="tns:FEXResponse_Idi" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Idi" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Idi" nillable="true" type="tns:ClsFEXResponse_Idi" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Idi_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_UMed">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_UMedResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_UMedResult" type="tns:FEXResponse_Umed" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Umed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_UMed" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_UMed" nillable="true" type="tns:ClsFEXResponse_UMed" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Umed_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_pais">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_paisResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_paisResult" type="tns:FEXResponse_DST_pais" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_pais" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_pais" nillable="true" type="tns:ClsFEXResponse_DST_pais" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_CUIT">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_CUITResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_CUITResult" type="tns:FEXResponse_DST_cuit" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_cuit" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_cuit" nillable="true" type="tns:ClsFEXResponse_DST_cuit" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="DST_CUIT" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MONResult" type="tns:FEXResponse_Mon" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon" nillable="true" type="tns:ClsFEXResponse_Mon" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACION">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Fecha_CTZ" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACIONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MON_CON_COTIZACIONResult" type="tns:FEXResponse_Mon_CON_COTIZACION" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon_CON_COTIZACION">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon_CON_Cotizacion" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon_CON_Cotizacion" nillable="true" type="tns:ClsFEXResponse_Mon_CON_Cotizacion" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_ctz" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_ctz" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEX_LastCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEX_LastCMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pto_venta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_CMPResult" type="tns:FEXResponseLast_CMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseLast_CMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResult_LastCMP" type="tns:ClsFEX_LastCMP_Response" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEX_LastCMP_Response">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXDummy">
+        <s:complexType />
+      </s:element>
+      <s:element name="FEXDummyResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXDummyResult" type="tns:DummyResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="DummyResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="AppServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DbServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="AuthServer" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Ctz">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Mon_id" type="s:string" />
+            <s:element minOccurs="0" maxOccurs="1" name="FchCotiz" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_CtzResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_CtzResult" type="tns:FEXResponse_Ctz" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_Ctz" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Mon_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_ID">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetLast_IDResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_IDResult" type="tns:FEXResponse_LastID" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_LastID" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_PtoVenta">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_PtoVentaResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_PtoVentaResult" type="tns:FEXResponse_PtoVenta" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_PtoVenta" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_PtoVenta" nillable="true" type="tns:ClsFEXResponse_PtoVenta" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Pve_Nro" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_Bloqueado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_FchBaja" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXCheck_Permiso">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="ID_Permiso" type="s:string" />
+            <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXCheck_PermisoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXCheck_PermisoResult" type="tns:FEXResponse_CheckPermiso" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_CheckPermiso" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Status" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Opcionales">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_OpcionalesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_OpcionalesResult" type="tns:FEXResponse_Opc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Opc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Opc" nillable="true" type="tns:ClsFEXResponse_Opc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Opc_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Actividades">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_ActividadesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_ActividadesResult" type="tns:FEXResponse_Actividades" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Actividades">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_ActividadTipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_ActividadTipo" nillable="true" type="tns:ClsFEXResponse_ActividadTipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Orden" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Desc" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="FEXAuthorizeSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXAuthorize" />
+  </wsdl:message>
+  <wsdl:message name="FEXAuthorizeSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXAuthorizeResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetCMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetCMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_Tipo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_TipoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_Expo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_ExpoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Incoterms" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IncotermsResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Idiomas" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IdiomasResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMed" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMedResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_pais" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_paisResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUIT" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUITResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACION" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACIONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapIn">
+    <wsdl:part name="parameters" element="tns:FEXDummy" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapOut">
+    <wsdl:part name="parameters" element="tns:FEXDummyResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Ctz" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_CtzResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_ID" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_IDResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVenta" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVentaResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXCheck_Permiso" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXCheck_PermisoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Opcionales" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_OpcionalesResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Actividades" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_ActividadesResponse" />
+  </wsdl:message>
+  <wsdl:portType name="ServiceSoap">
+    <wsdl:operation name="FEXAuthorize">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Autoriza un comprobante, devolviendo  su CAE correspondiente</wsdl:documentation>
+      <wsdl:input message="tns:FEXAuthorizeSoapIn" />
+      <wsdl:output message="tns:FEXAuthorizeSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera los datos completos de un comprobante ya autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetCMPSoapIn" />
+      <wsdl:output message="tns:FEXGetCMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de comprobante  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Cbte_TipoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Cbte_TipoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de exportacion  y sus codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Tipo_ExpoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Tipo_ExpoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado Incoterms  utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IncotermsSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IncotermsSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los idiomas  y sus codigos utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IdiomasSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IdiomasSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las unidades de medida  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_UMedSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_UMedSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de paises</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_paisSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_paisSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las cuits de los paises de destinacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_CUITSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_CUITSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas que tengan cotizacion de ADUANA a una fecha determinada, utilizables en el proceso de autorizacion de comprobantes de servicios</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimos comprobante autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_CMPSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_CMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Metodo dummy para verificacion de funcionamiento</wsdl:documentation>
+      <wsdl:input message="tns:FEXDummySoapIn" />
+      <wsdl:output message="tns:FEXDummySoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera la cotizacion de la moneda consultada y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_CtzSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_CtzSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimo ID y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_IDSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_IDSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los puntos de venta registrados para Factura electronica de exportacion - WS y su estado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_PtoVentaSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_PtoVentaSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifica la  existencia de la permiso/pais de destinación  de embarque ingresado</wsdl:documentation>
+      <wsdl:input message="tns:FEXCheck_PermisoSoapIn" />
+      <wsdl:output message="tns:FEXCheck_PermisoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de identificadores para los campos Opcionales</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_OpcionalesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_OpcionalesSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las diferentes actividades habilitadas para el emisor</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_ActividadesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_ActividadesSoapOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="ServiceSoap" type="tns:ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="ServiceSoap12" type="tns:ServiceSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Service">
+    <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+    <wsdl:port name="ServiceSoap" binding="tns:ServiceSoap">
+      <soap:address location="https://wswhomo.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+    <wsdl:port name="ServiceSoap12" binding="tns:ServiceSoap12">
+      <soap12:address location="https://wswhomo.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_inscription_proof-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
+  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
+  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
+  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
+  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosGenerales">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="caracterizacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="actividad">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
+      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="categoria">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="relacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="impuesto">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="regimen">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorConstancia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaListResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaListReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaListResponse">
+    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2Response">
+    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2Response">
+    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList">
+    <wsdl:part element="tns:getPersonaList" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2">
+    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2">
+    <wsdl:part element="tns:getPersona_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA5">
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaListResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersona_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaList_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA5">
+    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
+      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_inscription_proof.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
+  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
+  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
+  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
+  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosGenerales">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="caracterizacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="actividad">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
+      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="categoria">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="relacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="impuesto">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="regimen">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorConstancia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaListResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaListReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaListResponse">
+    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2Response">
+    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2Response">
+    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList">
+    <wsdl:part element="tns:getPersonaList" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2">
+    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2">
+    <wsdl:part element="tns:getPersona_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA5">
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaListResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersona_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaList_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA5">
+    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
+      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a10-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA10" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA10">
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA10SoapBinding" type="tns:PersonaServiceA10">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA10">
+    <wsdl:port binding="tns:PersonaServiceA10SoapBinding" name="PersonaServiceA10Port">
+      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA10"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a10.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA10" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a10.soap.ws.server.puc.sr/" xmlns:tns="http://a10.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA10">
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA10SoapBinding" type="tns:PersonaServiceA10">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA10">
+    <wsdl:port binding="tns:PersonaServiceA10SoapBinding" name="PersonaServiceA10Port">
+      <soap:address location="http://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA10"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a13-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA13" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getIdPersonaListByDocumento" type="tns:getIdPersonaListByDocumento"/>
+  <xs:element name="getIdPersonaListByDocumentoResponse" type="tns:getIdPersonaListByDocumentoResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getIdPersonaListByDocumento">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="documento" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getIdPersonaListByDocumentoResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="idPersonaListReturn" type="tns:idPersonaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="idPersonaListReturn">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="idPersona" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="periodoActividadPrincipal" type="xs:int"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="calle" type="xs:string"/>
+      <xs:element minOccurs="0" name="codigoPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoDomicilio" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="manzana" type="xs:string"/>
+      <xs:element minOccurs="0" name="numero" type="xs:int"/>
+      <xs:element minOccurs="0" name="oficinaDptoLocal" type="xs:string"/>
+      <xs:element minOccurs="0" name="piso" type="xs:string"/>
+      <xs:element minOccurs="0" name="sector" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+      <xs:element minOccurs="0" name="torre" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getIdPersonaListByDocumento">
+    <wsdl:part element="tns:getIdPersonaListByDocumento" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getIdPersonaListByDocumentoResponse">
+    <wsdl:part element="tns:getIdPersonaListByDocumentoResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA13">
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getIdPersonaListByDocumento">
+      <wsdl:input message="tns:getIdPersonaListByDocumento" name="getIdPersonaListByDocumento">
+    </wsdl:input>
+      <wsdl:output message="tns:getIdPersonaListByDocumentoResponse" name="getIdPersonaListByDocumentoResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA13SoapBinding" type="tns:PersonaServiceA13">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getIdPersonaListByDocumento">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getIdPersonaListByDocumento">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getIdPersonaListByDocumentoResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA13">
+    <wsdl:port binding="tns:PersonaServiceA13SoapBinding" name="PersonaServiceA13Port">
+      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA13"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a13.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA13" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a13.soap.ws.server.puc.sr/" xmlns:tns="http://a13.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getIdPersonaListByDocumento" type="tns:getIdPersonaListByDocumento"/>
+  <xs:element name="getIdPersonaListByDocumentoResponse" type="tns:getIdPersonaListByDocumentoResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getIdPersonaListByDocumento">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="documento" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getIdPersonaListByDocumentoResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="idPersonaListReturn" type="tns:idPersonaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="idPersonaListReturn">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="idPersona" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="descripcionActividadPrincipal" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividadPrincipal" type="xs:long"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="periodoActividadPrincipal" type="xs:int"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="calle" type="xs:string"/>
+      <xs:element minOccurs="0" name="codigoPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoDomicilio" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="manzana" type="xs:string"/>
+      <xs:element minOccurs="0" name="numero" type="xs:int"/>
+      <xs:element minOccurs="0" name="oficinaDptoLocal" type="xs:string"/>
+      <xs:element minOccurs="0" name="piso" type="xs:string"/>
+      <xs:element minOccurs="0" name="sector" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+      <xs:element minOccurs="0" name="torre" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getIdPersonaListByDocumento">
+    <wsdl:part element="tns:getIdPersonaListByDocumento" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getIdPersonaListByDocumentoResponse">
+    <wsdl:part element="tns:getIdPersonaListByDocumentoResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA13">
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getIdPersonaListByDocumento">
+      <wsdl:input message="tns:getIdPersonaListByDocumento" name="getIdPersonaListByDocumento">
+    </wsdl:input>
+      <wsdl:output message="tns:getIdPersonaListByDocumentoResponse" name="getIdPersonaListByDocumentoResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA13SoapBinding" type="tns:PersonaServiceA13">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getIdPersonaListByDocumento">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getIdPersonaListByDocumento">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getIdPersonaListByDocumentoResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA13">
+    <wsdl:port binding="tns:PersonaServiceA13SoapBinding" name="PersonaServiceA13Port">
+      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA13"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a4-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA4" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element minOccurs="0" name="cantidadSociosEmpresaMono" type="xs:int"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="categoria" nillable="true" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="email" nillable="true" type="tns:email"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaInscripcion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaJubilado" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaVencimientoMigracion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+      <xs:element minOccurs="0" name="leyJubilacion" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidadInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="organismoInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="organismoOriginante" type="xs:string"/>
+      <xs:element minOccurs="0" name="porcentajeCapitalNacional" type="xs:double"/>
+      <xs:element minOccurs="0" name="provinciaInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="relacion" nillable="true" type="tns:relacion"/>
+      <xs:element minOccurs="0" name="sexo" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="telefono" nillable="true" type="tns:telefono"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoOrganismoOriginante" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoResidencia" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="actividad">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
+      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="categoria">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="email">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoEmail" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="impuesto">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="ffInscripcion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="regimen">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
+      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="relacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
+      <xs:element minOccurs="0" name="subtipoRelacion" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoRelacion" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="telefono">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="numero" type="xs:long"/>
+      <xs:element minOccurs="0" name="tipoLinea" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoTelefono" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA4">
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA4SoapBinding" type="tns:PersonaServiceA4">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA4">
+    <wsdl:port binding="tns:PersonaServiceA4SoapBinding" name="PersonaServiceA4Port">
+      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA4"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a4.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA4" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a4.soap.ws.server.puc.sr/" xmlns:tns="http://a4.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element minOccurs="0" name="persona" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element minOccurs="0" name="cantidadSociosEmpresaMono" type="xs:int"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="categoria" nillable="true" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="claveInactivaAsociada" nillable="true" type="xs:long"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="domicilio" nillable="true" type="tns:domicilio"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="email" nillable="true" type="tns:email"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaInscripcion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaJubilado" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaNacimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaVencimientoMigracion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="formaJuridica" type="xs:string"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+      <xs:element minOccurs="0" name="leyJubilacion" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidadInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="numeroInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="organismoInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="organismoOriginante" type="xs:string"/>
+      <xs:element minOccurs="0" name="porcentajeCapitalNacional" type="xs:double"/>
+      <xs:element minOccurs="0" name="provinciaInscripcion" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="relacion" nillable="true" type="tns:relacion"/>
+      <xs:element minOccurs="0" name="sexo" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="telefono" nillable="true" type="tns:telefono"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDocumento" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoOrganismoOriginante" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoResidencia" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="actividad">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
+      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="categoria">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="email">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoEmail" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="impuesto">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="ffInscripcion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="regimen">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
+      <xs:element minOccurs="0" name="diaPeriodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="estado" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="relacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
+      <xs:element minOccurs="0" name="subtipoRelacion" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoRelacion" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="telefono">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="numero" type="xs:long"/>
+      <xs:element minOccurs="0" name="tipoLinea" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoTelefono" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA4">
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA4SoapBinding" type="tns:PersonaServiceA4">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA4">
+    <wsdl:port binding="tns:PersonaServiceA4SoapBinding" name="PersonaServiceA4Port">
+      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA4"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a5-production.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
+  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
+  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
+  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
+  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosGenerales">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="caracterizacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="actividad">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
+      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="categoria">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="relacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="impuesto">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="regimen">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorConstancia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaListResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaListReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaListResponse">
+    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2Response">
+    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2Response">
+    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList">
+    <wsdl:part element="tns:getPersonaList" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2">
+    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2">
+    <wsdl:part element="tns:getPersona_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA5">
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaListResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersona_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaList_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA5">
+    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
+      <soap:address location="https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>`,
+  'ws_sr_padron_a5.wsdl': `<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="PersonaServiceA5" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://a5.soap.ws.server.puc.sr/" xmlns:tns="http://a5.soap.ws.server.puc.sr/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dummy" type="tns:dummy"/>
+  <xs:element name="dummyResponse" type="tns:dummyResponse"/>
+  <xs:element name="getPersona" type="tns:getPersona"/>
+  <xs:element name="getPersonaList" type="tns:getPersonaList"/>
+  <xs:element name="getPersonaListResponse" type="tns:getPersonaListResponse"/>
+  <xs:element name="getPersonaList_v2" type="tns:getPersonaList_v2"/>
+  <xs:element name="getPersonaList_v2Response" type="tns:getPersonaList_v2Response"/>
+  <xs:element name="getPersonaResponse" type="tns:getPersonaResponse"/>
+  <xs:element name="getPersona_v2" type="tns:getPersona_v2"/>
+  <xs:element name="getPersona_v2Response" type="tns:getPersona_v2Response"/>
+  <xs:complexType name="getPersona">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosGenerales">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="caracterizacion" nillable="true" type="tns:caracterizacion"/>
+      <xs:element minOccurs="0" name="dependencia" type="tns:dependencia"/>
+      <xs:element minOccurs="0" name="domicilioFiscal" type="tns:domicilio"/>
+      <xs:element minOccurs="0" name="esSucesion" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="fechaContratoSocial" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="fechaFallecimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="mesCierre" type="xs:int"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocial" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoClave" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoPersona" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="caracterizacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCaracterizacion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCaracterizacion" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dependencia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionDependencia" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idDependencia" type="xs:int"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="domicilio">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="codPostal" type="xs:string"/>
+      <xs:element minOccurs="0" name="datoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="descripcionProvincia" type="xs:string"/>
+      <xs:element minOccurs="0" name="direccion" type="xs:string"/>
+      <xs:element minOccurs="0" name="idProvincia" type="xs:int"/>
+      <xs:element minOccurs="0" name="localidad" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDatoAdicional" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoDomicilio" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="actividadMonotributista" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaMonotributo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="componenteDeSociedad" nillable="true" type="tns:relacion"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="actividad">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionActividad" type="xs:string"/>
+      <xs:element minOccurs="0" name="idActividad" type="xs:long"/>
+      <xs:element minOccurs="0" name="nomenclador" type="xs:int"/>
+      <xs:element minOccurs="0" name="orden" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="categoria">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionCategoria" type="xs:string"/>
+      <xs:element minOccurs="0" name="idCategoria" type="xs:int"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="relacion">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellidoPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="ffRelacion" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="ffVencimiento" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="idPersonaAsociada" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombrePersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="razonSocialPersonaAsociada" type="xs:string"/>
+      <xs:element minOccurs="0" name="tipoComponente" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="impuesto">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="estadoImpuesto" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="motivo" type="xs:string"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datosRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="actividad" nillable="true" type="tns:actividad"/>
+      <xs:element minOccurs="0" name="categoriaAutonomo" type="tns:categoria"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="impuesto" nillable="true" type="tns:impuesto"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="regimen" nillable="true" type="tns:regimen"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="regimen">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="descripcionRegimen" type="xs:string"/>
+      <xs:element minOccurs="0" name="idImpuesto" type="xs:int"/>
+      <xs:element minOccurs="0" name="idRegimen" type="xs:int"/>
+      <xs:element minOccurs="0" name="periodo" type="xs:int"/>
+      <xs:element minOccurs="0" name="tipoRegimen" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorConstancia">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="apellido" type="xs:string"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="idPersona" type="xs:long"/>
+      <xs:element minOccurs="0" name="nombre" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorMonotributo">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="errorRegimenGeneral">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="error" nillable="true" type="xs:string"/>
+      <xs:element minOccurs="0" name="mensaje" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="metadata">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="fechaHora" type="xs:dateTime"/>
+      <xs:element minOccurs="0" name="servidor" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaListResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="personaListReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="metadata" type="tns:metadata"/>
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="persona" nillable="true" type="tns:persona"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="persona">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="datosGenerales" type="tns:datosGenerales"/>
+      <xs:element minOccurs="0" name="datosMonotributo" type="tns:datosMonotributo"/>
+      <xs:element minOccurs="0" name="datosRegimenGeneral" type="tns:datosRegimenGeneral"/>
+      <xs:element minOccurs="0" name="errorConstancia" type="tns:errorConstancia"/>
+      <xs:element minOccurs="0" name="errorMonotributo" type="tns:errorMonotributo"/>
+      <xs:element minOccurs="0" name="errorRegimenGeneral" type="tns:errorRegimenGeneral"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersona_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaReturn" type="tns:personaReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummy">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="dummyResponse">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="return" type="tns:dummyReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dummyReturn">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="appserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="authserver" type="xs:string"/>
+      <xs:element minOccurs="0" name="dbserver" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2">
+    <xs:sequence>
+      <xs:element name="token" type="xs:string"/>
+      <xs:element name="sign" type="xs:string"/>
+      <xs:element name="cuitRepresentada" type="xs:long"/>
+      <xs:element maxOccurs="unbounded" name="idPersona" type="xs:long"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="getPersonaList_v2Response">
+    <xs:sequence>
+      <xs:element minOccurs="0" name="personaListReturn" type="tns:personaListReturn"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="SRValidationException" type="tns:SRValidationException"/>
+  <xs:complexType name="SRValidationException">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getPersonaListResponse">
+    <wsdl:part element="tns:getPersonaListResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummyResponse">
+    <wsdl:part element="tns:dummyResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona">
+    <wsdl:part element="tns:getPersona" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2Response">
+    <wsdl:part element="tns:getPersonaList_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2Response">
+    <wsdl:part element="tns:getPersona_v2Response" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList">
+    <wsdl:part element="tns:getPersonaList" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaResponse">
+    <wsdl:part element="tns:getPersonaResponse" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="dummy">
+    <wsdl:part element="tns:dummy" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersonaList_v2">
+    <wsdl:part element="tns:getPersonaList_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SRValidationException">
+    <wsdl:part element="tns:SRValidationException" name="SRValidationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPersona_v2">
+    <wsdl:part element="tns:getPersona_v2" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="PersonaServiceA5">
+    <wsdl:operation name="getPersona">
+      <wsdl:input message="tns:getPersona" name="getPersona">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaResponse" name="getPersonaResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <wsdl:input message="tns:getPersonaList" name="getPersonaList">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaListResponse" name="getPersonaListResponse">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <wsdl:input message="tns:getPersona_v2" name="getPersona_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersona_v2Response" name="getPersona_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <wsdl:input message="tns:dummy" name="dummy">
+    </wsdl:input>
+      <wsdl:output message="tns:dummyResponse" name="dummyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <wsdl:input message="tns:getPersonaList_v2" name="getPersonaList_v2">
+    </wsdl:input>
+      <wsdl:output message="tns:getPersonaList_v2Response" name="getPersonaList_v2Response">
+    </wsdl:output>
+      <wsdl:fault message="tns:SRValidationException" name="SRValidationException">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="PersonaServiceA5SoapBinding" type="tns:PersonaServiceA5">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getPersona">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaListResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getPersona_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersona_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersona_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="dummy">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="dummy">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="dummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getPersonaList_v2">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getPersonaList_v2">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPersonaList_v2Response">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="SRValidationException">
+        <soap:fault name="SRValidationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="PersonaServiceA5">
+    <wsdl:port binding="tns:PersonaServiceA5SoapBinding" name="PersonaServiceA5Port">
+      <soap:address location="https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA5"/>
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>`

--- a/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfecred-production.wsdl
+++ b/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfecred-production.wsdl
@@ -1,0 +1,1802 @@
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://ar.gob.afip.wsfecred/FECredService/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="FECredService" targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+			<xsd:element name="dummyResponse" type="tns:DummyResponseType" />
+			<xsd:complexType name="DummyResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="dummyReturn" type="tns:DummyReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="DummyReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="appserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="authserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="dbserver" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="AuthRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="token" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="sign" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitRepresentada" type="tns:CuitSimpleType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="CuitSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minExclusive value="9999999999" />
+					<xsd:maxInclusive value="99999999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ArrayCodigosDescripcionesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcion" type="tns:CodigoDescripcionType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ArrayCodigosDescripcionesStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcionString" type="tns:CodigoDescripcionStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+
+
+			<xsd:element name="consultarComprobantesRequest" type="tns:ConsultarComprobanteRequestType" />
+			<xsd:element name="consultarComprobantesResponse" type="tns:ConsultarComprobantesResponseType" />
+			<xsd:complexType name="ConsultarComprobanteRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCmp" type="tns:EstadoCmpSimpleType" />
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType" />
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="codCtaCte" type="xsd:long" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarComprobantesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCmpReturn" type="tns:ConsultarCmpReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarCmpReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayComprobantes" type="tns:ArrayComprobantesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+	            	</xsd:element>
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:simpleType name="ResultadoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="O" />
+					<xsd:enumeration value="R" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="NumeroComprobanteSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="PuntoVentaSimpleType">
+				<xsd:restriction base="xsd:int">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:element name="rechazarFECredRequest" type="tns:RechazarFECredRequestType" />
+			<xsd:element name="rechazarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="RechazarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarCtaCteRequest" type="tns:ConsultarCtaCteRequestType" />
+			<xsd:element name="consultarCtaCteResponse" type="tns:ConsultarCtaCteResponseType" />
+			<xsd:complexType name="ConsultarCtaCteRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:element name="rechazarNotaDCRequest" type="tns:RechazarNotaDCRequestType">
+			</xsd:element>
+			<xsd:element name="rechazarNotaDCResponse" type="tns:RechazarNotaDCResponseType" />
+			<xsd:complexType name="RechazarNotaDCRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="informarFacturaAgtDptoCltvRequest" type="tns:InformarFacturaAgtDptoCltvRequestType" />
+			<xsd:element name="informarFacturaAgtDptoCltvResponse" type="tns:OperacionFECredResponseType" />
+			
+			<xsd:element name="consultarCuentasEnAgtDptoCltvRequest" type="tns:ConsultarCuentasEnAgtDptoCltvRequestType" />
+			<xsd:element name="consultarCuentasEnAgtDptoCltvResponse" type="tns:consultarCuentasEnAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="Texto250SimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="3" />
+					<xsd:maxLength value="250" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+
+
+			<xsd:element name="consultarTiposRetencionesRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposRetencionesResponse" type="tns:ConsultarTiposRetencionesResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCtasCtesRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType">
+					</xsd:element>
+
+
+
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarObligadoRecepcionRequest" type="tns:consultarObligadoRecepcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarObligadoRecepcionResponse" type="tns:consultarObligadoRecepcionResponseType">
+			</xsd:element>
+			
+			<xsd:element name="consultarFacturasAgtDptoCltvRequest" type="tns:ConsultarFacturasAgtDptoCltvRequestType">
+			</xsd:element>
+			<xsd:element name="consultarFacturasAgtDptoCltvResponse" type="tns:ConsultarFacturasAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredResponse" type="tns:OperacionFECredResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredRequest" type="tns:InformarCancelacionTotalFECredRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCodigoDescripcionReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:element name="consultarTiposFormasCancelacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposFormasCancelacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+
+			<xsd:element name="aceptarFECredRequest" type="tns:AceptarFECredRequestType">
+			</xsd:element>
+			<xsd:element name="aceptarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="AceptarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayConfirmarNotasDC" type="tns:ArrayConfirmarNotasType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoCancelacion" type="tns:TipoCancelacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="saldoAceptado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+					</xsd:element>
+
+					<xsd:element name="informaCBU" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="CBUComprador" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			
+            <xsd:complexType name="IdCtaCteType">
+                <xsd:sequence>
+                    <xsd:choice maxOccurs="1" minOccurs="1">
+                        <xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType" />
+                    </xsd:choice>
+                </xsd:sequence>
+            </xsd:complexType>
+			
+            <xsd:group name="NewGroupDefinition">
+				<xsd:sequence />
+			</xsd:group>
+			<xsd:simpleType name="SiNoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:length value="1" />
+					<xsd:enumeration value="S" />
+					<xsd:enumeration value="N" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitEmisor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialEmi" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptovta" type="tns:PuntoVentaSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitReceptor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialRecep" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="tipoCodAuto" type="tns:TipoCodAutorizacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codAutorizacion" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaPuestaDispo" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenPago" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenAcep" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="importeTotal" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMoneda" type="xsd:decimal">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUEmisor" type="tns:CBUSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="AliasEmisor" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esAnulacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esPostAceptacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="idComprobanteAsociado" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="referenciasComerciales" type="tns:ArrayTexto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arraySubtotalesIVA" type="tns:ArraySubtotalesIVAType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayOtrosTributos" type="tns:ArrayOtrosTributosType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayItems" type="tns:ArrayItemsType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosGenerales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosComerciales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="leyendaComercial" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpType">
+					</xsd:element>
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoAcep" type="tns:TipoAceptacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaHoraAcep" type="xsd:dateTime">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="infoTransferencia" type="tns:InfoTransferenciaType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="ImporteSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="-9999999999999.99" />
+					<xsd:maxInclusive value="9999999999999.99" />
+					<xsd:totalDigits value="15" />
+					<xsd:fractionDigits value="2" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="DecimalSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="0" />
+					<xsd:maxInclusive value="999999999999.999999" />
+					<xsd:totalDigits value="18" />
+					<xsd:fractionDigits value="6" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		
+
+			<xsd:complexType name="ConsultarCodigoDescripcionRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="InformarCancelacionTotalFECredRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+				    <xsd:element maxOccurs="1" minOccurs="1" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="importeCancelacion" type="tns:ImporteSimpleType">
+				    </xsd:element>
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:complexType name="ConsultarCodigoDescripcionResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+				
+			
+			<xsd:element name="consultarCtasCtesRequest" type="tns:ConsultarCtasCtesRequestType">
+			</xsd:element>
+			<xsd:element name="consultarCtasCtesResponse" type="tns:ConsultarCtasCtesResponseType" />
+
+
+
+
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionStringReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+		
+			<xsd:simpleType name="TipoCodAutorizacionType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="E" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarTiposRetencionesReturn" type="tns:ConsultarTiposRetencionesReturnType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesReturnType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayTiposRetenciones" type="tns:ArrayTiposRetencionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayTiposRetencionesType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="tipoRetencion" type="tns:TipoRetencionType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="TipoRetencionType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="codigoJurisdiccion" type="xsd:short">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="descripcionJurisdiccion" type="xsd:string" />
+			        <xsd:element maxOccurs="1" minOccurs="1" name="porcentajeRetencion" type="tns:PorcentajeSimpleType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="PorcentajeSimpleType">
+			    <xsd:restriction base="xsd:decimal">
+			        <xsd:maxInclusive value="100.00" />
+			        <xsd:minInclusive value="0.0" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionRequestType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType" />
+
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarObligadoRecepcionReturn" type="tns:consultarObligadoRecepcionReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="respuesta" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="desde" type="xsd:date" />
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+
+		
+			<xsd:complexType name="consultarCuentasEnAgtDptoCltvResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarCuentasEnAgtDptoCltvReturn" type="tns:ConsultarCuentasEnAgtDptoCltvReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayCuentasEnAgente" type="tns:ArrayCuentasEnAgenteType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType" />
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			    	</xsd:element>
+			        
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayCuentasEnAgenteType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="cuentaEnAgente" type="tns:CuentaEnAgenteType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="CuentaEnAgenteType">
+			    <xsd:sequence>
+			    	<xsd:element name="cuitAgente" type="tns:CuitSimpleType" maxOccurs="1" minOccurs="1">
+			    	</xsd:element>
+			    	<xsd:element name="razonSocialAgente" type="xsd:string" maxOccurs="1" minOccurs="0" />
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="idCuenta" type="tns:IdCuentaAgenteSimpleType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="denominacion" type="tns:Texto250SimpleType">
+			    	</xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="CBUSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:length value="22" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+			
+			<xsd:simpleType name="IdCuentaAgenteSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:minLength value="3" />
+					<xsd:maxLength value="20" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="FiltroFechaType">
+				<xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="tipo" type="tns:TipoFechaSimpleType" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="desde" type="xsd:date" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="hasta" type="xsd:date" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoFechaSimpleType">
+				<xsd:annotation>
+					<xsd:documentation>
+						Campo que determina sobre que columna vamos a
+						hacer el filtro de fechas. Fechas posibles a
+						filtrar - fechaEmision - fechaPuestaDispo -
+						fechaVenPago - fechaVenAcep - fechaAcep -
+						fechaInfoAgDptoCltv
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:restriction base="xsd:string">
+
+
+
+					<xsd:enumeration value="Emision" />
+					<xsd:enumeration value="PuestaDispo" />
+					<xsd:enumeration value="VenPago" />
+					<xsd:enumeration value="VenAcep" />
+					<xsd:enumeration value="Acep" />
+					<xsd:enumeration value="InfoAgDptoCltv" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="RolSimpleType">
+				<xsd:restriction base="xsd:string">
+
+
+					<xsd:enumeration value="Emisor" />
+					<xsd:enumeration value="Receptor" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCmpSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="PendienteRecepcion" />
+					<xsd:enumeration value="Recepcionado" />
+					<xsd:enumeration value="Aceptado" />
+					<xsd:enumeration value="Rechazado" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCtaCteSimpleType">
+				<xsd:restriction base="xsd:string">
+
+					<xsd:enumeration value="Modificable" />
+					<xsd:enumeration value="Aceptada" />
+					<xsd:enumeration value="Rechazada" />
+					<xsd:enumeration value="CanceladaTotal" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="ArrayComprobantesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="comprobante" type="tns:ComprobanteType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoAceptacionSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="Tacita" />
+					<xsd:enumeration value="Expresa" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="IdComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="CUITEmisor" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptoVta" type="tns:PuntoVentaSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rechazarNotaDCReturn" type="tns:RechazarNotaDCReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCtasCtesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtasCtesReturn" type="tns:ConsultarCtasCtesReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtasCtesReturnType">
+            <xsd:sequence>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayInfosCtaCte" type="tns:ArrayInfosCtaCteType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	</xsd:element>
+            </xsd:sequence>
+
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayInfosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="infoCtaCte" type="tns:InfoCtaCteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFacturaCredito" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeTotalFC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string" />
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtaCteReturn" type="tns:ConsultarCtaCteReturnType">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="ctaCte" type="tns:CuentaCorrienteType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayConfirmarNotasType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="confirmarNota" type="tns:ConfirmarNotaDCType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConfirmarNotaDCType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="acepta" type="tns:SiNoSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idNota" type="tns:IdComprobanteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="CuentaCorrienteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="factura" type="tns:ComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayNotasDCAsociadas" type="tns:ArrayComprobantesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeInicial" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalNotasDC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+            		</xsd:element>
+
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayRetencionesType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="retencion" type="tns:RetencionType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="RetencionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codTipo" type="xsd:short" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="porcentaje" type="tns:PorcentajeSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="descMotivo" type="tns:Texto250SimpleType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="operacionFECredReturn" type="tns:OperacionFECredReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredReturnType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+        
+            <xsd:simpleType name="TipoCancelacionSimpleType">
+            	<xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="PAR" />
+            		<xsd:enumeration value="TOT" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InformarFacturaAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="idCtaCte" type="tns:IdCtaCteType" />
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="filtroFecha" type="tns:FiltroFechaType">
+            	    </xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarFacturasAgtDptoCltvReturn" type="tns:ConsultarFacturasAgtDptoCltvReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFacturasAgtDptoCltv" type="tns:ArrayFacturasAgtDptoCltvType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayFacturasAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="facturaInformada" type="tns:FacturaInformadaAgtDptoCltvType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="FacturaInformadaAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+	           	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="obtenerRemitosRequest" type="tns:ObtenerRemitosRequestType" />
+            <xsd:element name="obtenerRemitosResponse" type="tns:ObtenerRemitosResponseType">
+            </xsd:element>
+            <xsd:complexType name="ObtenerRemitosRequestType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosResponseType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="obtenerRemitosReturn" type="tns:ObtenerRemitosReturnType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosReturnType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayIdsRemitos" type="tns:ArrayIdsComprobantesType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayIdsComprobantesType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="1" name="idsComprobantes" type="tns:IdComprobanteType">
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArraySubtotalesIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="subtotalIVA" type="tns:SubtotalIVAType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="ArrayOtrosTributosType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="otroTributo" type="tns:OtroTributoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="SubtotalIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OtroTributoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="detalle" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayMotivosRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="motivoRechazo" type="tns:MotivoRechazoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="MotivoRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMotivo" type="xsd:short">
+					</xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="descMotivo" type="tns:Texto250SimpleType">
+					</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="justificacion" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="EstadoCmpType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosComprobanteRequest" type="tns:ConsultarHistorialEstadosComprobanteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosComprobanteResponse" type="tns:ConsultarHistorialEstadosComprobanteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+				    
+				</xsd:sequence>            
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosComprobanteReturn" type="tns:ConsultarHistorialEstadosComprobanteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosComprobanteType">
+            		</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayHistorialEstadosComprobanteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCmpType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosCtaCteRequest" type="tns:ConsultarHistorialEstadosCtaCteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosCtaCteResponse" type="tns:consultarHistorialEstadosCtaCteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosCtaCteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+				    
+				</xsd:sequence>  
+            </xsd:complexType>
+        
+            <xsd:complexType name="consultarHistorialEstadosCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosCtaCteReturn" type="tns:consultarHistorialEstadosCtaCteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="consultarHistorialEstadosCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayHistorialEstadosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="EstadoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCtaCteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayItemsType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="item" type="tns:ItemType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ItemType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="orden" type="xsd:int">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="unidadesMtx" type="xsd:int" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoMtx" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigo" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codNomMercosur" type="xsd:string" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="cantidad" type="tns:DecimalSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoUnidadMedida" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="precioUnitario" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeBonificacion" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigoCondicionIVA" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeIVA" type="tns:ImporteSimpleType">
+            		</xsd:element>
+
+                    <xsd:element maxOccurs="1" minOccurs="1" name="importeItem" type="tns:ImporteSimpleType">
+            		</xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayTexto250SimpleType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="texto" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarTiposAjustesOperacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarTiposAjustesOperacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+
+            </xsd:element>
+		
+            <xsd:complexType name="ArrayAjustesOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="ajuste" type="tns:AjusteOperacionType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="AjusteOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarMontoObligadoRecepcionRequest" type="tns:ConsultarMontoObligadoRecepcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarMontoObligadoRecepcionResponse" type="tns:ConsultarMontoObligadoRecepcionResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarMontoObligadoRecepcionReturn" type="tns:ConsultarMontoObligadoRecepcionReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionReturnType">
+            	<xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="obligado" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="montoDesde" type="tns:ImporteSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:simpleType name="OpcionTransferenciaSimpleType">
+                <xsd:annotation>
+                	<xsd:documentation>SCA - Sistema de Circulación Abierta
+ADC - Agente de Depósito Colectivo</xsd:documentation>
+                </xsd:annotation>
+                <xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="SCA" />
+            		<xsd:enumeration value="ADC" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InfoTransferenciaType">
+            	<xsd:sequence>
+            		<xsd:choice maxOccurs="1" minOccurs="1">
+            			<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            			<xsd:element name="infoSCA" type="tns:InfoSCAType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            		</xsd:choice>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaInfo" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="recibida" type="tns:SiNoSimpleType">
+            		</xsd:element>
+            		<xsd:element name="fechaLectura" type="xsd:date" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="fechaRecep" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="aceptada" type="tns:SiNoSimpleType" />
+            		<xsd:element name="motivoRechazo" type="xsd:string" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="idPagoAgtDptoCltv" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUAgtDptoCltv" type="tns:CBUSimpleType">
+					</xsd:element>
+            		
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="InfoSCAType">
+            	<xsd:sequence>
+            		<xsd:element name="fechaAceptacionFactura" type="xsd:date" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="informaCBUReceptor" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="CBUReceptor" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="CBUValidada" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="fechaLecturaSCA" type="xsd:dateTime" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaResponse" type="tns:OperacionFECredResponseType">
+
+            </xsd:element>
+
+            <xsd:complexType name="ModificarOpcionTransferenciaRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+            		</xsd:element>
+
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaRequest" type="tns:ModificarOpcionTransferenciaRequestType">
+            </xsd:element>
+		</xsd:schema>
+	</wsdl:types>
+
+
+	<wsdl:message name="dummyRequest" />
+
+	<wsdl:message name="dummyResponse">
+		<wsdl:part element="tns:dummyResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesRequest">
+		<wsdl:part element="tns:consultarComprobantesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesResponse">
+		<wsdl:part element="tns:consultarComprobantesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredRequest">
+		<wsdl:part element="tns:rechazarFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredResponse">
+		<wsdl:part element="tns:rechazarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteRequest">
+		<wsdl:part element="tns:consultarCtaCteRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteResponse">
+		<wsdl:part element="tns:consultarCtaCteResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCRequest">
+		<wsdl:part element="tns:rechazarNotaDCRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCResponse">
+		<wsdl:part element="tns:rechazarNotaDCResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvRequest">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvResponse">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteRequest">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteResponse">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesRequest">
+		<wsdl:part element="tns:consultarTiposRetencionesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesResponse">
+		<wsdl:part element="tns:consultarTiposRetencionesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvRequest">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvResponse">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredRequest">
+		<wsdl:part element="tns:informarCancelacionTotalFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredResponse">
+		<wsdl:part element="tns:informarCancelacionTotalFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+	<wsdl:message name="consultarTiposMotivosRechazoRequest">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposMotivosRechazoResponse">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionRequest">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionResponse">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="aceptarFECredRequest">
+		<wsdl:part element="tns:aceptarFECredRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="aceptarFECredResponse">
+		<wsdl:part element="tns:aceptarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+
+	<wsdl:message name="consultarCtasCtesRequest">
+		<wsdl:part element="tns:consultarCtasCtesRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarCtasCtesResponse">
+		<wsdl:part element="tns:consultarCtasCtesResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosRequest">
+	    <wsdl:part element="tns:obtenerRemitosRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosResponse">
+	    <wsdl:part element="tns:obtenerRemitosResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionRequest">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionResponse">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaRequest">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaRequest" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaResponse">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaResponse" />
+	</wsdl:message>
+	<wsdl:portType name="FECredServicePortType">
+
+		<wsdl:operation name="dummy">
+			<wsdl:documentation>Metodo dummy.</wsdl:documentation>
+			<wsdl:input message="tns:dummyRequest" />
+			<wsdl:output message="tns:dummyResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarComprobantes">
+			<wsdl:documentation>Método que permite obtener información sobre los comprobates Emitidos y Recibidos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarComprobantesRequest" />
+			<wsdl:output message="tns:consultarComprobantesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarNotaDC">
+			<wsdl:documentation>Método que permite al Comprador rechazar Notas de Débito / Crédito individualmente para
+				desafectarlas del cálculo del saldo de la Cta. Cte. vinculada.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarNotaDCRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:rechazarNotaDCResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtasCtes">
+			<wsdl:documentation>Método que permite obtener las cuentas corrientes que fueron generadas a partir de la
+				facturación, que coinciden con los parámetros de búsqueda.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtasCtesRequest" />
+			<wsdl:output message="tns:consultarCtasCtesResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtaCte">
+			<wsdl:documentation>Método que permite obtener el detalle y composición de una cuenta corriente.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaCteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaCteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<wsdl:documentation>Método por el cual el Comprador informa que le ha cancelado (pagado) totalmente la deuda al
+				vendedor, debiendo indicar la forma de pago.Solo puede cancelar las aceptadas dentros de los plazos establecidos
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarCancelacionTotalFECredRequest" />
+			<wsdl:output message="tns:informarCancelacionTotalFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="aceptarFECred">
+			<wsdl:documentation>Método que permite al Comprador Aceptar el saldo actual de la Cta. Cte. de una Factura de Crédito
+				pudiendo indicar: pagos parciales, retenciones y/o embargos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:aceptarFECredRequest" />
+			<wsdl:output message="tns:aceptarFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarFECred">
+			<wsdl:documentation>Método que permite al Comprador Rechazar la Cta. Cte. de una Factura de Crédito debiendo indicar
+				el motivo del rechazo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarFECredRequest" />
+			<wsdl:output message="tns:rechazarFECredResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor solicitar la transeferencia (al Agente de Depósito Colectivo) de
+				la factura de crédito con el saldo resultante de la cuenta corriente vinculada aceptada por el comprador, debiendo
+				indicar la Cuenta del Agente de Deposito Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarFacturaAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:informarFacturaAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<wsdl:documentation>Método que permite obtener información sobre las transeferencias realizadas al Agente de Depósito
+				Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarFacturasAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarFacturasAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor consultar sus cuentas en sus Agentes de Deposito Colectivo
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaAgenteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaAgenteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<wsdl:documentation>Método que permite a partir de una CUIT conocer su obligación respecto a la emisión o recepción
+				de facturas de créditos
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarObligadoRecepcionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarObligadoRecepcionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposRetenciones">
+			<wsdl:documentation>Método que permite consultar los tipos de retenciones habilitadas con sus respectivos porcentajes.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposRetencionesRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposRetencionesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<wsdl:documentation>Método que permite listar los tipos de  motivos de rechazo habilitados para una cta. cte.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposMotivosRechazoRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposMotivosRechazoResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<wsdl:documentation>Método que permite listar los tipos de formas de pago habilitados para una factura de crédito.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposFormasCancelacionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposFormasCancelacionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+		    <wsdl:input message="tns:obtenerRemitosRequest" />
+		    <wsdl:output message="tns:obtenerRemitosResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<wsdl:input message="tns:consultarHistorialEstadosComprobanteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosComprobanteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<wsdl:input message="tns:consultarHistorialEstadosCtaCteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosCtaCteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<wsdl:input message="tns:consultarTiposAjustesOperacionRequest" />
+			<wsdl:output message="tns:consultarTiposAjustesOperacionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<wsdl:input message="tns:consultarMontoObligadoRecepcionRequest" />
+			<wsdl:output message="tns:consultarMontoObligadoRecepcionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<wsdl:input message="tns:modificarOpcionTransferenciaRequest" />
+			<wsdl:output message="tns:modificarOpcionTransferenciaResponse" />
+		</wsdl:operation>
+	</wsdl:portType>
+
+
+	<wsdl:binding name="FECredServiceSOAP" type="tns:FECredServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="dummy">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/dummy" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarComprobantes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarComprobantes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtasCtes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtasCtes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarNotaDC">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarNotaDC" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarFacturaAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposRetenciones">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposRetenciones" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarFacturasAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarCancelacionTotalFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposMotivosRechazo" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposFormasCancelacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="aceptarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/aceptarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCuentasEnAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/obtenerRemitos" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosComprobante" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposAjustesOperacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarMontoObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/modificarOpcionTransferencia" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="FECredService">
+		<wsdl:port binding="tns:FECredServiceSOAP" name="FECredServiceSOAP">
+			<soap:address location="https://serviciosjava.afip.gob.ar:443/wsfecred/FECredService" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfecred.wsdl
+++ b/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfecred.wsdl
@@ -1,0 +1,1802 @@
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://ar.gob.afip.wsfecred/FECredService/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="FECredService" targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://ar.gob.afip.wsfecred/FECredService/">
+			<xsd:element name="dummyResponse" type="tns:DummyResponseType" />
+			<xsd:complexType name="DummyResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="dummyReturn" type="tns:DummyReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="DummyReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="appserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="authserver" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="dbserver" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="AuthRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="token" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="sign" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitRepresentada" type="tns:CuitSimpleType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="CuitSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minExclusive value="9999999999" />
+					<xsd:maxInclusive value="99999999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ArrayCodigosDescripcionesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcion" type="tns:CodigoDescripcionType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ArrayCodigosDescripcionesStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="codigoDescripcionString" type="tns:CodigoDescripcionStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="CodigoDescripcionStringType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:string" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+
+
+			<xsd:element name="consultarComprobantesRequest" type="tns:ConsultarComprobanteRequestType" />
+			<xsd:element name="consultarComprobantesResponse" type="tns:ConsultarComprobantesResponseType" />
+			<xsd:complexType name="ConsultarComprobanteRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCmp" type="tns:EstadoCmpSimpleType" />
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType" />
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="codCtaCte" type="xsd:long" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarComprobantesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCmpReturn" type="tns:ConsultarCmpReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="ConsultarCmpReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayComprobantes" type="tns:ArrayComprobantesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+	            	</xsd:element>
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+	            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:simpleType name="ResultadoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="O" />
+					<xsd:enumeration value="R" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="NumeroComprobanteSimpleType">
+				<xsd:restriction base="xsd:long">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="PuntoVentaSimpleType">
+				<xsd:restriction base="xsd:int">
+					<xsd:minInclusive value="1" />
+					<xsd:maxInclusive value="99999" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:element name="rechazarFECredRequest" type="tns:RechazarFECredRequestType" />
+			<xsd:element name="rechazarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="RechazarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarCtaCteRequest" type="tns:ConsultarCtaCteRequestType" />
+			<xsd:element name="consultarCtaCteResponse" type="tns:ConsultarCtaCteResponseType" />
+			<xsd:complexType name="ConsultarCtaCteRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:element name="rechazarNotaDCRequest" type="tns:RechazarNotaDCRequestType">
+			</xsd:element>
+			<xsd:element name="rechazarNotaDCResponse" type="tns:RechazarNotaDCResponseType" />
+			<xsd:complexType name="RechazarNotaDCRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="informarFacturaAgtDptoCltvRequest" type="tns:InformarFacturaAgtDptoCltvRequestType" />
+			<xsd:element name="informarFacturaAgtDptoCltvResponse" type="tns:OperacionFECredResponseType" />
+			
+			<xsd:element name="consultarCuentasEnAgtDptoCltvRequest" type="tns:ConsultarCuentasEnAgtDptoCltvRequestType" />
+			<xsd:element name="consultarCuentasEnAgtDptoCltvResponse" type="tns:consultarCuentasEnAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="Texto250SimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="3" />
+					<xsd:maxLength value="250" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+
+
+			<xsd:element name="consultarTiposRetencionesRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposRetencionesResponse" type="tns:ConsultarTiposRetencionesResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCtasCtesRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rolCUITRepresentada" type="tns:RolSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CUITContraparte" type="tns:CuitSimpleType">
+					</xsd:element>
+
+
+
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="fecha" type="tns:FiltroFechaType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="estadoCtaCte" type="tns:EstadoCtaCteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short" />
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:element name="consultarObligadoRecepcionRequest" type="tns:consultarObligadoRecepcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarObligadoRecepcionResponse" type="tns:consultarObligadoRecepcionResponseType">
+			</xsd:element>
+			
+			<xsd:element name="consultarFacturasAgtDptoCltvRequest" type="tns:ConsultarFacturasAgtDptoCltvRequestType">
+			</xsd:element>
+			<xsd:element name="consultarFacturasAgtDptoCltvResponse" type="tns:ConsultarFacturasAgtDptoCltvResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredResponse" type="tns:OperacionFECredResponseType">
+			</xsd:element>
+			<xsd:element name="informarCancelacionTotalFECredRequest" type="tns:InformarCancelacionTotalFECredRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposMotivosRechazoResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+			<xsd:complexType name="ConsultarCodigoDescripcionReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:element name="consultarTiposFormasCancelacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+			</xsd:element>
+			<xsd:element name="consultarTiposFormasCancelacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+			</xsd:element>
+
+			<xsd:element name="aceptarFECredRequest" type="tns:AceptarFECredRequestType">
+			</xsd:element>
+			<xsd:element name="aceptarFECredResponse" type="tns:OperacionFECredResponseType" />
+			<xsd:complexType name="AceptarFECredRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayConfirmarNotasDC" type="tns:ArrayConfirmarNotasType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoCancelacion" type="tns:TipoCancelacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="saldoAceptado" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+					</xsd:element>
+
+					<xsd:element name="informaCBU" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="CBUComprador" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+			
+            <xsd:complexType name="IdCtaCteType">
+                <xsd:sequence>
+                    <xsd:choice maxOccurs="1" minOccurs="1">
+                        <xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+                        <xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType" />
+                    </xsd:choice>
+                </xsd:sequence>
+            </xsd:complexType>
+			
+            <xsd:group name="NewGroupDefinition">
+				<xsd:sequence />
+			</xsd:group>
+			<xsd:simpleType name="SiNoSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:length value="1" />
+					<xsd:enumeration value="S" />
+					<xsd:enumeration value="N" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:complexType name="ComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitEmisor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialEmi" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptovta" type="tns:PuntoVentaSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cuitReceptor" type="tns:CuitSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="razonSocialRecep" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="tipoCodAuto" type="tns:TipoCodAutorizacionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codAutorizacion" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaPuestaDispo" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenPago" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaVenAcep" type="xsd:date">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="importeTotal" type="tns:ImporteSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMoneda" type="xsd:decimal">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUEmisor" type="tns:CBUSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="AliasEmisor" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esAnulacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="esPostAceptacion" type="tns:SiNoSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="idComprobanteAsociado" type="tns:IdComprobanteType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="referenciasComerciales" type="tns:ArrayTexto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arraySubtotalesIVA" type="tns:ArraySubtotalesIVAType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayOtrosTributos" type="tns:ArrayOtrosTributosType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayItems" type="tns:ArrayItemsType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosGenerales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="datosComerciales" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="leyendaComercial" type="tns:Texto250SimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpType">
+					</xsd:element>
+
+
+					<xsd:element maxOccurs="1" minOccurs="0" name="tipoAcep" type="tns:TipoAceptacionSimpleType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="fechaHoraAcep" type="xsd:dateTime">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayMotivosRechazo" type="tns:ArrayMotivosRechazoType">
+					</xsd:element>
+
+					<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+					<xsd:element name="infoTransferencia" type="tns:InfoTransferenciaType" maxOccurs="1" minOccurs="0">
+					</xsd:element>
+
+
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:simpleType name="ImporteSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="-9999999999999.99" />
+					<xsd:maxInclusive value="9999999999999.99" />
+					<xsd:totalDigits value="15" />
+					<xsd:fractionDigits value="2" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			<xsd:simpleType name="DecimalSimpleType">
+				<xsd:restriction base="xsd:decimal">
+					<xsd:minInclusive value="0" />
+					<xsd:maxInclusive value="999999999999.999999" />
+					<xsd:totalDigits value="18" />
+					<xsd:fractionDigits value="6" />
+				</xsd:restriction>
+			</xsd:simpleType>
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		
+
+			<xsd:complexType name="ConsultarCodigoDescripcionRequestType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType" />
+				</xsd:sequence>
+			</xsd:complexType>
+			<xsd:complexType name="InformarCancelacionTotalFECredRequestType">
+				<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+				    <xsd:element maxOccurs="1" minOccurs="1" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="importeCancelacion" type="tns:ImporteSimpleType">
+				    </xsd:element>
+
+				</xsd:sequence>
+			</xsd:complexType>
+			
+			<xsd:complexType name="ConsultarCodigoDescripcionResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+
+				
+			
+			<xsd:element name="consultarCtasCtesRequest" type="tns:ConsultarCtasCtesRequestType">
+			</xsd:element>
+			<xsd:element name="consultarCtasCtesResponse" type="tns:ConsultarCtasCtesResponseType" />
+
+
+
+
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="codigoDescripcionReturn" type="tns:ConsultarCodigoDescripcionStringReturnType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+			<xsd:complexType name="ConsultarCodigoDescripcionStringReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayCodigoDescripcion" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:complexType>
+
+
+		
+			<xsd:simpleType name="TipoCodAutorizacionType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="A" />
+					<xsd:enumeration value="E" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarTiposRetencionesReturn" type="tns:ConsultarTiposRetencionesReturnType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarTiposRetencionesReturnType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayTiposRetenciones" type="tns:ArrayTiposRetencionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayTiposRetencionesType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="tipoRetencion" type="tns:TipoRetencionType" />
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="TipoRetencionType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="codigoJurisdiccion" type="xsd:short">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="descripcionJurisdiccion" type="xsd:string" />
+			        <xsd:element maxOccurs="1" minOccurs="1" name="porcentajeRetencion" type="tns:PorcentajeSimpleType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="PorcentajeSimpleType">
+			    <xsd:restriction base="xsd:decimal">
+			        <xsd:maxInclusive value="100.00" />
+			        <xsd:minInclusive value="0.0" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionRequestType">
+			    <xsd:sequence>
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType" />
+
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarObligadoRecepcionReturn" type="tns:consultarObligadoRecepcionReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="consultarObligadoRecepcionReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="respuesta" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="desde" type="xsd:date" />
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+
+		
+			<xsd:complexType name="consultarCuentasEnAgtDptoCltvResponseType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="1" name="consultarCuentasEnAgtDptoCltvReturn" type="tns:ConsultarCuentasEnAgtDptoCltvReturnType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCuentasEnAgtDptoCltvReturnType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayCuentasEnAgente" type="tns:ArrayCuentasEnAgenteType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType" />
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			    	</xsd:element>
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			    	</xsd:element>
+			        
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ArrayCuentasEnAgenteType">
+			    <xsd:sequence>
+			        <xsd:element maxOccurs="unbounded" minOccurs="1" name="cuentaEnAgente" type="tns:CuentaEnAgenteType">
+			        </xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="CuentaEnAgenteType">
+			    <xsd:sequence>
+			    	<xsd:element name="cuitAgente" type="tns:CuitSimpleType" maxOccurs="1" minOccurs="1">
+			    	</xsd:element>
+			    	<xsd:element name="razonSocialAgente" type="xsd:string" maxOccurs="1" minOccurs="0" />
+			    	<xsd:element maxOccurs="1" minOccurs="1" name="idCuenta" type="tns:IdCuentaAgenteSimpleType">
+			    	</xsd:element>
+
+			    	<xsd:element maxOccurs="1" minOccurs="0" name="denominacion" type="tns:Texto250SimpleType">
+			    	</xsd:element>
+			    </xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="CBUSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:length value="22" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+			
+			<xsd:simpleType name="IdCuentaAgenteSimpleType">
+			    <xsd:restriction base="xsd:string">
+			        <xsd:minLength value="3" />
+					<xsd:maxLength value="20" />
+			    </xsd:restriction>
+			</xsd:simpleType>
+		
+			<xsd:complexType name="FiltroFechaType">
+				<xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="tipo" type="tns:TipoFechaSimpleType" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="desde" type="xsd:date" />
+                    <xsd:element maxOccurs="1" minOccurs="1" name="hasta" type="xsd:date" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoFechaSimpleType">
+				<xsd:annotation>
+					<xsd:documentation>
+						Campo que determina sobre que columna vamos a
+						hacer el filtro de fechas. Fechas posibles a
+						filtrar - fechaEmision - fechaPuestaDispo -
+						fechaVenPago - fechaVenAcep - fechaAcep -
+						fechaInfoAgDptoCltv
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:restriction base="xsd:string">
+
+
+
+					<xsd:enumeration value="Emision" />
+					<xsd:enumeration value="PuestaDispo" />
+					<xsd:enumeration value="VenPago" />
+					<xsd:enumeration value="VenAcep" />
+					<xsd:enumeration value="Acep" />
+					<xsd:enumeration value="InfoAgDptoCltv" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="RolSimpleType">
+				<xsd:restriction base="xsd:string">
+
+
+					<xsd:enumeration value="Emisor" />
+					<xsd:enumeration value="Receptor" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCmpSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="PendienteRecepcion" />
+					<xsd:enumeration value="Recepcionado" />
+					<xsd:enumeration value="Aceptado" />
+					<xsd:enumeration value="Rechazado" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:simpleType name="EstadoCtaCteSimpleType">
+				<xsd:restriction base="xsd:string">
+
+					<xsd:enumeration value="Modificable" />
+					<xsd:enumeration value="Aceptada" />
+					<xsd:enumeration value="Rechazada" />
+					<xsd:enumeration value="CanceladaTotal" />
+					<xsd:enumeration value="InformadaAgDpto" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="ArrayComprobantesType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" name="comprobante" type="tns:ComprobanteType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:simpleType name="TipoAceptacionSimpleType">
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="Tacita" />
+					<xsd:enumeration value="Expresa" />
+				</xsd:restriction>
+			</xsd:simpleType>
+
+			<xsd:complexType name="IdComprobanteType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="CUITEmisor" type="tns:CuitSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="codTipoCmp" type="xsd:short" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="ptoVta" type="tns:PuntoVentaSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="nroCmp" type="tns:NumeroComprobanteSimpleType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="rechazarNotaDCReturn" type="tns:RechazarNotaDCReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="RechazarNotaDCReturnType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+					<xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+			<xsd:complexType name="ConsultarCtasCtesResponseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtasCtesReturn" type="tns:ConsultarCtasCtesReturnType" />
+				</xsd:sequence>
+			</xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtasCtesReturnType">
+            <xsd:sequence>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayInfosCtaCte" type="tns:ArrayInfosCtaCteType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="nroPagina" type="xsd:short">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="hayMas" type="tns:SiNoSimpleType" />
+            	<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	</xsd:element>
+            	<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	</xsd:element>
+            </xsd:sequence>
+
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayInfosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="infoCtaCte" type="tns:InfoCtaCteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFacturaCredito" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeTotalFC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string" />
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarCtaCteReturn" type="tns:ConsultarCtaCteReturnType">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="ctaCte" type="tns:CuentaCorrienteType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+					</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayConfirmarNotasType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="confirmarNota" type="tns:ConfirmarNotaDCType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConfirmarNotaDCType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="acepta" type="tns:SiNoSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idNota" type="tns:IdComprobanteType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="CuentaCorrienteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codCtaCte" type="xsd:long">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estadoCtaCte" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="factura" type="tns:ComprobanteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayNotasDCAsociadas" type="tns:ArrayComprobantesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFormasCancelacion" type="tns:ArrayCodigosDescripcionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayRetenciones" type="tns:ArrayRetencionesType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayAjustesOperacion" type="tns:ArrayAjustesOperacionType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importeInicial" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalNotasDC" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeCancelado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeTotalRetPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeEmbargoPesos" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="saldoAceptado" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="saldo" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMoneda" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cotizacionMonedaUlt" type="xsd:decimal">
+            		</xsd:element>
+
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayRetencionesType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="retencion" type="tns:RetencionType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="RetencionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codTipo" type="xsd:short" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="porcentaje" type="tns:PorcentajeSimpleType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="descMotivo" type="tns:Texto250SimpleType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="operacionFECredReturn" type="tns:OperacionFECredReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OperacionFECredReturnType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="resultado" type="tns:ResultadoSimpleType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+        
+            <xsd:simpleType name="TipoCancelacionSimpleType">
+            	<xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="PAR" />
+            		<xsd:enumeration value="TOT" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InformarFacturaAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            	    </xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvRequestType">
+            	<xsd:sequence>
+            	    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            	    </xsd:element>
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="idCtaCte" type="tns:IdCtaCteType" />
+            	    <xsd:element maxOccurs="1" minOccurs="0" name="filtroFecha" type="tns:FiltroFechaType">
+            	    </xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarFacturasAgtDptoCltvReturn" type="tns:ConsultarFacturasAgtDptoCltvReturnType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarFacturasAgtDptoCltvReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayFacturasAgtDptoCltv" type="tns:ArrayFacturasAgtDptoCltvType" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="evento" type="tns:CodigoDescripcionType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayObservaciones" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayFacturasAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="facturaInformada" type="tns:FacturaInformadaAgtDptoCltvType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="FacturaInformadaAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idFactura" type="tns:IdComprobanteType">
+            		</xsd:element>
+            		<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+	           	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="obtenerRemitosRequest" type="tns:ObtenerRemitosRequestType" />
+            <xsd:element name="obtenerRemitosResponse" type="tns:ObtenerRemitosResponseType">
+            </xsd:element>
+            <xsd:complexType name="ObtenerRemitosRequestType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosResponseType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="obtenerRemitosReturn" type="tns:ObtenerRemitosReturnType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ObtenerRemitosReturnType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayIdsRemitos" type="tns:ArrayIdsComprobantesType">
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+                    <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayIdsComprobantesType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="1" name="idsComprobantes" type="tns:IdComprobanteType">
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArraySubtotalesIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="subtotalIVA" type="tns:SubtotalIVAType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="ArrayOtrosTributosType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="otroTributo" type="tns:OtroTributoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="SubtotalIVAType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="OtroTributoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="detalle" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="baseImponible" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayMotivosRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="motivoRechazo" type="tns:MotivoRechazoType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="MotivoRechazoType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codMotivo" type="xsd:short">
+					</xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1" name="descMotivo" type="tns:Texto250SimpleType">
+					</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="justificacion" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            
+            <xsd:complexType name="EstadoCmpType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCmpSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosComprobanteRequest" type="tns:ConsultarHistorialEstadosComprobanteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosComprobanteResponse" type="tns:ConsultarHistorialEstadosComprobanteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType">
+					</xsd:element>
+				    
+				</xsd:sequence>            
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosComprobanteReturn" type="tns:ConsultarHistorialEstadosComprobanteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarHistorialEstadosComprobanteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idComprobante" type="tns:IdComprobanteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosComprobanteType">
+            		</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayHistorialEstadosComprobanteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCmpType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarHistorialEstadosCtaCteRequest" type="tns:ConsultarHistorialEstadosCtaCteRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarHistorialEstadosCtaCteResponse" type="tns:consultarHistorialEstadosCtaCteResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarHistorialEstadosCtaCteRequestType">
+            	<xsd:sequence>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+				    </xsd:element>
+				    <xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+					</xsd:element>
+				    
+				</xsd:sequence>  
+            </xsd:complexType>
+        
+            <xsd:complexType name="consultarHistorialEstadosCtaCteResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarHistorialEstadosCtaCteReturn" type="tns:consultarHistorialEstadosCtaCteReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="consultarHistorialEstadosCtaCteReturnType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="arrayHistorialEstados" type="tns:ArrayHistorialEstadosCtaCteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType" />
+					<xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType" />
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayHistorialEstadosCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="estadoHistorico" type="tns:EstadoCtaCteType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="EstadoCtaCteType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="estado" type="tns:EstadoCtaCteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaHoraEstado" type="xsd:dateTime">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ArrayItemsType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="item" type="tns:ItemType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ItemType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="orden" type="xsd:int">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="unidadesMtx" type="xsd:int" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoMtx" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigo" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="descripcion" type="xsd:string">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codNomMercosur" type="xsd:string" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="cantidad" type="tns:DecimalSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="codigoUnidadMedida" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="precioUnitario" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeBonificacion" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigoCondicionIVA" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="importeIVA" type="tns:ImporteSimpleType">
+            		</xsd:element>
+
+                    <xsd:element maxOccurs="1" minOccurs="1" name="importeItem" type="tns:ImporteSimpleType">
+            		</xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ArrayTexto250SimpleType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="texto" type="tns:Texto250SimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarTiposAjustesOperacionRequest" type="tns:ConsultarCodigoDescripcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarTiposAjustesOperacionResponse" type="tns:ConsultarCodigoDescripcionResponseType">
+
+            </xsd:element>
+		
+            <xsd:complexType name="ArrayAjustesOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="unbounded" minOccurs="1" name="ajuste" type="tns:AjusteOperacionType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="AjusteOperacionType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="codigo" type="xsd:short">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="importe" type="tns:ImporteSimpleType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="consultarMontoObligadoRecepcionRequest" type="tns:ConsultarMontoObligadoRecepcionRequestType">
+
+            </xsd:element>
+            <xsd:element name="consultarMontoObligadoRecepcionResponse" type="tns:ConsultarMontoObligadoRecepcionResponseType">
+
+            </xsd:element>
+            
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="cuitConsultada" type="tns:CuitSimpleType">
+            		</xsd:element>
+
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaEmision" type="xsd:date">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionResponseType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="consultarMontoObligadoRecepcionReturn" type="tns:ConsultarMontoObligadoRecepcionReturnType">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="ConsultarMontoObligadoRecepcionReturnType">
+            	<xsd:sequence>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="obligado" type="tns:SiNoSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="montoDesde" type="tns:ImporteSimpleType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayObservacion" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErrores" type="tns:ArrayCodigosDescripcionesType">
+			        </xsd:element>
+			        <xsd:element maxOccurs="1" minOccurs="0" name="arrayErroresFormato" type="tns:ArrayCodigosDescripcionesStringType">
+			        </xsd:element>
+			    </xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:simpleType name="OpcionTransferenciaSimpleType">
+                <xsd:annotation>
+                	<xsd:documentation>SCA - Sistema de Circulación Abierta
+ADC - Agente de Depósito Colectivo</xsd:documentation>
+                </xsd:annotation>
+                <xsd:restriction base="xsd:string">
+            		<xsd:enumeration value="SCA" />
+            		<xsd:enumeration value="ADC" />
+            	</xsd:restriction>
+            </xsd:simpleType>
+		
+            <xsd:complexType name="InfoTransferenciaType">
+            	<xsd:sequence>
+            		<xsd:choice maxOccurs="1" minOccurs="1">
+            			<xsd:element name="infoAgtDptoCltv" type="tns:InfoAgtDptoCltvType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            			<xsd:element name="infoSCA" type="tns:InfoSCAType" maxOccurs="1" minOccurs="1">
+            			</xsd:element>
+            		</xsd:choice>
+
+            	</xsd:sequence>
+            </xsd:complexType>
+		
+            <xsd:complexType name="InfoAgtDptoCltvType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="fechaInfo" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="1" name="ctaAgente" type="tns:CuentaEnAgenteType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="recibida" type="tns:SiNoSimpleType">
+            		</xsd:element>
+            		<xsd:element name="fechaLectura" type="xsd:date" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="fechaRecep" type="xsd:date" />
+            		<xsd:element maxOccurs="1" minOccurs="0" name="aceptada" type="tns:SiNoSimpleType" />
+            		<xsd:element name="motivoRechazo" type="xsd:string" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="0" name="idPagoAgtDptoCltv" type="xsd:string">
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="CBUAgtDptoCltv" type="tns:CBUSimpleType">
+					</xsd:element>
+            		
+            	</xsd:sequence>
+            </xsd:complexType>
+        
+            <xsd:complexType name="InfoSCAType">
+            	<xsd:sequence>
+            		<xsd:element name="fechaAceptacionFactura" type="xsd:date" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="informaCBUReceptor" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            		<xsd:element name="CBUReceptor" type="tns:CBUSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="CBUValidada" type="tns:SiNoSimpleType" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            		<xsd:element name="fechaLecturaSCA" type="xsd:dateTime" maxOccurs="1" minOccurs="0">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaResponse" type="tns:OperacionFECredResponseType">
+
+            </xsd:element>
+
+            <xsd:complexType name="ModificarOpcionTransferenciaRequestType">
+            	<xsd:sequence>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="authRequest" type="tns:AuthRequestType">
+            		</xsd:element>
+            		<xsd:element maxOccurs="1" minOccurs="1" name="idCtaCte" type="tns:IdCtaCteType">
+            		</xsd:element>
+
+            		<xsd:element name="opcionTransferencia" type="tns:OpcionTransferenciaSimpleType" maxOccurs="1" minOccurs="1">
+            		</xsd:element>
+            	</xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="modificarOpcionTransferenciaRequest" type="tns:ModificarOpcionTransferenciaRequestType">
+            </xsd:element>
+		</xsd:schema>
+	</wsdl:types>
+
+
+	<wsdl:message name="dummyRequest" />
+
+	<wsdl:message name="dummyResponse">
+		<wsdl:part element="tns:dummyResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesRequest">
+		<wsdl:part element="tns:consultarComprobantesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarComprobantesResponse">
+		<wsdl:part element="tns:consultarComprobantesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredRequest">
+		<wsdl:part element="tns:rechazarFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="rechazarFECredResponse">
+		<wsdl:part element="tns:rechazarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteRequest">
+		<wsdl:part element="tns:consultarCtaCteRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaCteResponse">
+		<wsdl:part element="tns:consultarCtaCteResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCRequest">
+		<wsdl:part element="tns:rechazarNotaDCRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="rechazarNotaDCResponse">
+		<wsdl:part element="tns:rechazarNotaDCResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvRequest">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarFacturaAgtDptoCltvResponse">
+		<wsdl:part element="tns:informarFacturaAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteRequest">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarCtaAgenteResponse">
+		<wsdl:part element="tns:consultarCuentasEnAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesRequest">
+		<wsdl:part element="tns:consultarTiposRetencionesRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposRetencionesResponse">
+		<wsdl:part element="tns:consultarTiposRetencionesResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvRequest">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarFacturasAgtDptoCltvResponse">
+		<wsdl:part element="tns:consultarFacturasAgtDptoCltvResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredRequest">
+		<wsdl:part element="tns:informarCancelacionTotalFECredRequest" name="parameters">
+		</wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="informarCancelacionTotalFECredResponse">
+		<wsdl:part element="tns:informarCancelacionTotalFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+	<wsdl:message name="consultarTiposMotivosRechazoRequest">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposMotivosRechazoResponse">
+		<wsdl:part element="tns:consultarTiposMotivosRechazoResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionRequest">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionRequest" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="consultarTiposFormasCancelacionResponse">
+		<wsdl:part element="tns:consultarTiposFormasCancelacionResponse" name="parameters" />
+	</wsdl:message>
+
+	<wsdl:message name="aceptarFECredRequest">
+		<wsdl:part element="tns:aceptarFECredRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="aceptarFECredResponse">
+		<wsdl:part element="tns:aceptarFECredResponse" name="parameters" />
+	</wsdl:message>
+
+
+
+	<wsdl:message name="consultarCtasCtesRequest">
+		<wsdl:part element="tns:consultarCtasCtesRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarCtasCtesResponse">
+		<wsdl:part element="tns:consultarCtasCtesResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosRequest">
+	    <wsdl:part element="tns:obtenerRemitosRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="obtenerRemitosResponse">
+	    <wsdl:part element="tns:obtenerRemitosResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosComprobanteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosComprobanteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteRequest">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarHistorialEstadosCtaCteResponse">
+		<wsdl:part element="tns:consultarHistorialEstadosCtaCteResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionRequest">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarTiposAjustesOperacionResponse">
+		<wsdl:part element="tns:consultarTiposAjustesOperacionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionRequest">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionRequest" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="consultarMontoObligadoRecepcionResponse">
+		<wsdl:part element="tns:consultarMontoObligadoRecepcionResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaRequest">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaRequest" />
+	</wsdl:message>
+	<wsdl:message name="modificarOpcionTransferenciaResponse">
+		<wsdl:part name="parameters" element="tns:modificarOpcionTransferenciaResponse" />
+	</wsdl:message>
+	<wsdl:portType name="FECredServicePortType">
+
+		<wsdl:operation name="dummy">
+			<wsdl:documentation>Metodo dummy.</wsdl:documentation>
+			<wsdl:input message="tns:dummyRequest" />
+			<wsdl:output message="tns:dummyResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarComprobantes">
+			<wsdl:documentation>Método que permite obtener información sobre los comprobates Emitidos y Recibidos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarComprobantesRequest" />
+			<wsdl:output message="tns:consultarComprobantesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarNotaDC">
+			<wsdl:documentation>Método que permite al Comprador rechazar Notas de Débito / Crédito individualmente para
+				desafectarlas del cálculo del saldo de la Cta. Cte. vinculada.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarNotaDCRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:rechazarNotaDCResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtasCtes">
+			<wsdl:documentation>Método que permite obtener las cuentas corrientes que fueron generadas a partir de la
+				facturación, que coinciden con los parámetros de búsqueda.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtasCtesRequest" />
+			<wsdl:output message="tns:consultarCtasCtesResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCtaCte">
+			<wsdl:documentation>Método que permite obtener el detalle y composición de una cuenta corriente.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaCteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaCteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<wsdl:documentation>Método por el cual el Comprador informa que le ha cancelado (pagado) totalmente la deuda al
+				vendedor, debiendo indicar la forma de pago.Solo puede cancelar las aceptadas dentros de los plazos establecidos
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarCancelacionTotalFECredRequest" />
+			<wsdl:output message="tns:informarCancelacionTotalFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="aceptarFECred">
+			<wsdl:documentation>Método que permite al Comprador Aceptar el saldo actual de la Cta. Cte. de una Factura de Crédito
+				pudiendo indicar: pagos parciales, retenciones y/o embargos.
+			</wsdl:documentation>
+			<wsdl:input message="tns:aceptarFECredRequest" />
+			<wsdl:output message="tns:aceptarFECredResponse" />
+		</wsdl:operation>
+
+		<wsdl:operation name="rechazarFECred">
+			<wsdl:documentation>Método que permite al Comprador Rechazar la Cta. Cte. de una Factura de Crédito debiendo indicar
+				el motivo del rechazo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:rechazarFECredRequest" />
+			<wsdl:output message="tns:rechazarFECredResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor solicitar la transeferencia (al Agente de Depósito Colectivo) de
+				la factura de crédito con el saldo resultante de la cuenta corriente vinculada aceptada por el comprador, debiendo
+				indicar la Cuenta del Agente de Deposito Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:informarFacturaAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:informarFacturaAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<wsdl:documentation>Método que permite obtener información sobre las transeferencias realizadas al Agente de Depósito
+				Colectivo.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarFacturasAgtDptoCltvRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarFacturasAgtDptoCltvResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<wsdl:documentation>Método que permite al Vendedor consultar sus cuentas en sus Agentes de Deposito Colectivo
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarCtaAgenteRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarCtaAgenteResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<wsdl:documentation>Método que permite a partir de una CUIT conocer su obligación respecto a la emisión o recepción
+				de facturas de créditos
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarObligadoRecepcionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarObligadoRecepcionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposRetenciones">
+			<wsdl:documentation>Método que permite consultar los tipos de retenciones habilitadas con sus respectivos porcentajes.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposRetencionesRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposRetencionesResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<wsdl:documentation>Método que permite listar los tipos de  motivos de rechazo habilitados para una cta. cte.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposMotivosRechazoRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposMotivosRechazoResponse">
+			</wsdl:output>
+		</wsdl:operation>
+
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<wsdl:documentation>Método que permite listar los tipos de formas de pago habilitados para una factura de crédito.
+			</wsdl:documentation>
+			<wsdl:input message="tns:consultarTiposFormasCancelacionRequest">
+			</wsdl:input>
+			<wsdl:output message="tns:consultarTiposFormasCancelacionResponse">
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+		    <wsdl:input message="tns:obtenerRemitosRequest" />
+		    <wsdl:output message="tns:obtenerRemitosResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<wsdl:input message="tns:consultarHistorialEstadosComprobanteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosComprobanteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<wsdl:input message="tns:consultarHistorialEstadosCtaCteRequest" />
+			<wsdl:output message="tns:consultarHistorialEstadosCtaCteResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<wsdl:input message="tns:consultarTiposAjustesOperacionRequest" />
+			<wsdl:output message="tns:consultarTiposAjustesOperacionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<wsdl:input message="tns:consultarMontoObligadoRecepcionRequest" />
+			<wsdl:output message="tns:consultarMontoObligadoRecepcionResponse" />
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<wsdl:input message="tns:modificarOpcionTransferenciaRequest" />
+			<wsdl:output message="tns:modificarOpcionTransferenciaResponse" />
+		</wsdl:operation>
+	</wsdl:portType>
+
+
+	<wsdl:binding name="FECredServiceSOAP" type="tns:FECredServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="dummy">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/dummy" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarComprobantes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarComprobantes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtasCtes">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtasCtes" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="rechazarNotaDC">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/rechazarNotaDC" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarFacturaAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarFacturaAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposRetenciones">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposRetenciones" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarFacturasAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarFacturasAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="informarCancelacionTotalFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/informarCancelacionTotalFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposMotivosRechazo">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposMotivosRechazo" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposFormasCancelacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposFormasCancelacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="aceptarFECred">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/aceptarFECred" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarCuentasEnAgtDptoCltv">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarCuentasEnAgtDptoCltv" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="obtenerRemitos">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/obtenerRemitos" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosComprobante">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosComprobante" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarHistorialEstadosCtaCte">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarHistorialEstadosCtaCte" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarTiposAjustesOperacion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarTiposAjustesOperacion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="consultarMontoObligadoRecepcion">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/consultarMontoObligadoRecepcion" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="modificarOpcionTransferencia">
+			<soap:operation soapAction="http://ar.gob.afip.wsfecred/FECredService/modificarOpcionTransferencia" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="FECredService">
+		<wsdl:port binding="tns:FECredServiceSOAP" name="FECredServiceSOAP">
+			<soap:address location="https://fwshomo.afip.gov.ar:443/wsfecred/FECredService" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfex-production.wsdl
+++ b/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfex-production.wsdl
@@ -1,0 +1,1330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://ar.gov.afip.dif.fexv1/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://ar.gov.afip.dif.fexv1/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://ar.gov.afip.dif.fexv1/">
+      <s:element name="FEXAuthorize">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXAuthRequest">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXRequest">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Permiso" nillable="true" type="tns:Permiso" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Permiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id_permiso" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfCmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Cmp_asoc" nillable="true" type="tns:Cmp_asoc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Cmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfItem">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Item" nillable="true" type="tns:Item" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Item">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_qty" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_umed" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_precio_uni" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_bonificacion" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_total_item" type="s:decimal" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfOpcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Opcional" nillable="true" type="tns:Opcional" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Opcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Valor" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfActividad">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Actividad" nillable="true" type="tns:Actividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Actividad">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXAuthorizeResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXAuthorizeResult" type="tns:FEXResponseAuthorize" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseAuthorize">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultAuth" type="tns:ClsFEXOutAuthorize" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXOutAuthorize">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_cbte" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Reproceso" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXErr">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="ErrCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="ErrMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXEvents">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="EventCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="EventMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXGetCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXGetCMP">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetCMPResult" type="tns:FEXGetCMPResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXGetCMPResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXGetCMPR" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXGetCMPR">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte_cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Cbte_Tipo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Cbte_TipoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Cbte_TipoResult" type="tns:FEXResponse_Cbte_Tipo" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Cbte_Tipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Cbte_Tipo" nillable="true" type="tns:ClsFEXResponse_Cbte_Tipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Tipo_Expo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Tipo_ExpoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Tipo_ExpoResult" type="tns:FEXResponse_Tex" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Tex" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Tex" nillable="true" type="tns:ClsFEXResponse_Tex" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Tex_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Incoterms">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IncotermsResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IncotermsResult" type="tns:FEXResponse_Inc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Inc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Inc" nillable="true" type="tns:ClsFEXResponse_Inc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Idiomas">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IdiomasResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IdiomasResult" type="tns:FEXResponse_Idi" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Idi" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Idi" nillable="true" type="tns:ClsFEXResponse_Idi" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Idi_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_UMed">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_UMedResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_UMedResult" type="tns:FEXResponse_Umed" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Umed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_UMed" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_UMed" nillable="true" type="tns:ClsFEXResponse_UMed" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Umed_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_pais">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_paisResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_paisResult" type="tns:FEXResponse_DST_pais" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_pais" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_pais" nillable="true" type="tns:ClsFEXResponse_DST_pais" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_CUIT">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_CUITResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_CUITResult" type="tns:FEXResponse_DST_cuit" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_cuit" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_cuit" nillable="true" type="tns:ClsFEXResponse_DST_cuit" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="DST_CUIT" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MONResult" type="tns:FEXResponse_Mon" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon" nillable="true" type="tns:ClsFEXResponse_Mon" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACION">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Fecha_CTZ" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACIONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MON_CON_COTIZACIONResult" type="tns:FEXResponse_Mon_CON_COTIZACION" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon_CON_COTIZACION">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon_CON_Cotizacion" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon_CON_Cotizacion" nillable="true" type="tns:ClsFEXResponse_Mon_CON_Cotizacion" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_ctz" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_ctz" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEX_LastCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEX_LastCMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pto_venta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_CMPResult" type="tns:FEXResponseLast_CMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseLast_CMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResult_LastCMP" type="tns:ClsFEX_LastCMP_Response" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEX_LastCMP_Response">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXDummy">
+        <s:complexType />
+      </s:element>
+      <s:element name="FEXDummyResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXDummyResult" type="tns:DummyResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="DummyResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="AppServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DbServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="AuthServer" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Ctz">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Mon_id" type="s:string" />
+            <s:element minOccurs="0" maxOccurs="1" name="FchCotiz" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_CtzResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_CtzResult" type="tns:FEXResponse_Ctz" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_Ctz" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Mon_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_ID">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetLast_IDResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_IDResult" type="tns:FEXResponse_LastID" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_LastID" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_PtoVenta">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_PtoVentaResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_PtoVentaResult" type="tns:FEXResponse_PtoVenta" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_PtoVenta" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_PtoVenta" nillable="true" type="tns:ClsFEXResponse_PtoVenta" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Pve_Nro" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_Bloqueado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_FchBaja" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXCheck_Permiso">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="ID_Permiso" type="s:string" />
+            <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXCheck_PermisoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXCheck_PermisoResult" type="tns:FEXResponse_CheckPermiso" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_CheckPermiso" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Status" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Opcionales">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_OpcionalesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_OpcionalesResult" type="tns:FEXResponse_Opc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Opc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Opc" nillable="true" type="tns:ClsFEXResponse_Opc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Opc_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Actividades">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_ActividadesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_ActividadesResult" type="tns:FEXResponse_Actividades" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Actividades">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_ActividadTipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_ActividadTipo" nillable="true" type="tns:ClsFEXResponse_ActividadTipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Orden" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Desc" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="FEXAuthorizeSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXAuthorize" />
+  </wsdl:message>
+  <wsdl:message name="FEXAuthorizeSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXAuthorizeResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetCMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetCMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_Tipo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_TipoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_Expo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_ExpoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Incoterms" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IncotermsResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Idiomas" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IdiomasResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMed" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMedResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_pais" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_paisResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUIT" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUITResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACION" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACIONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapIn">
+    <wsdl:part name="parameters" element="tns:FEXDummy" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapOut">
+    <wsdl:part name="parameters" element="tns:FEXDummyResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Ctz" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_CtzResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_ID" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_IDResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVenta" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVentaResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXCheck_Permiso" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXCheck_PermisoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Opcionales" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_OpcionalesResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Actividades" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_ActividadesResponse" />
+  </wsdl:message>
+  <wsdl:portType name="ServiceSoap">
+    <wsdl:operation name="FEXAuthorize">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Autoriza un comprobante, devolviendo  su CAE correspondiente</wsdl:documentation>
+      <wsdl:input message="tns:FEXAuthorizeSoapIn" />
+      <wsdl:output message="tns:FEXAuthorizeSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera los datos completos de un comprobante ya autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetCMPSoapIn" />
+      <wsdl:output message="tns:FEXGetCMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de comprobante  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Cbte_TipoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Cbte_TipoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de exportacion  y sus codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Tipo_ExpoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Tipo_ExpoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado Incoterms  utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IncotermsSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IncotermsSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los idiomas  y sus codigos utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IdiomasSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IdiomasSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las unidades de medida  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_UMedSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_UMedSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de paises</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_paisSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_paisSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las cuits de los paises de destinacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_CUITSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_CUITSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas que tengan cotizacion de ADUANA a una fecha determinada, utilizables en el proceso de autorizacion de comprobantes de servicios</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimos comprobante autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_CMPSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_CMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Metodo dummy para verificacion de funcionamiento</wsdl:documentation>
+      <wsdl:input message="tns:FEXDummySoapIn" />
+      <wsdl:output message="tns:FEXDummySoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera la cotizacion de la moneda consultada y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_CtzSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_CtzSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimo ID y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_IDSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_IDSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los puntos de venta registrados para Factura electronica de exportacion - WS y su estado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_PtoVentaSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_PtoVentaSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifica la  existencia de la permiso/pais de destinación  de embarque ingresado</wsdl:documentation>
+      <wsdl:input message="tns:FEXCheck_PermisoSoapIn" />
+      <wsdl:output message="tns:FEXCheck_PermisoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de identificadores para los campos Opcionales</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_OpcionalesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_OpcionalesSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las diferentes actividades habilitadas para el emisor</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_ActividadesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_ActividadesSoapOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="ServiceSoap" type="tns:ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="ServiceSoap12" type="tns:ServiceSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Service">
+    <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+    <wsdl:port name="ServiceSoap" binding="tns:ServiceSoap">
+      <soap:address location="https://servicios1.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+    <wsdl:port name="ServiceSoap12" binding="tns:ServiceSoap12">
+      <soap12:address location="https://servicios1.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfex.wsdl
+++ b/packages/core/src/infrastructure/outbound/adapters/soap/wsdl/wsfex.wsdl
@@ -1,0 +1,1330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://ar.gov.afip.dif.fexv1/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://ar.gov.afip.dif.fexv1/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://ar.gov.afip.dif.fexv1/">
+      <s:element name="FEXAuthorize">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXAuthRequest">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXRequest">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Permiso" nillable="true" type="tns:Permiso" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Permiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id_permiso" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfCmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Cmp_asoc" nillable="true" type="tns:Cmp_asoc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Cmp_asoc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_cuit" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfItem">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Item" nillable="true" type="tns:Item" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Item">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pro_ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_qty" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_umed" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_precio_uni" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_bonificacion" type="s:decimal" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pro_total_item" type="s:decimal" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfOpcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Opcional" nillable="true" type="tns:Opcional" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Opcional">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Valor" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfActividad">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Actividad" nillable="true" type="tns:Actividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="Actividad">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXAuthorizeResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXAuthorizeResult" type="tns:FEXResponseAuthorize" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseAuthorize">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultAuth" type="tns:ClsFEXOutAuthorize" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXOutAuthorize">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_cbte" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Reproceso" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXErr">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="ErrCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="ErrMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXEvents">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="EventCode" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="EventMsg" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Cmp" type="tns:ClsFEXGetCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEXGetCMP">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetCMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetCMPResult" type="tns:FEXGetCMPResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXGetCMPResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXGetCMPR" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXGetCMPR">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_tipo" type="s:short" />
+          <s:element minOccurs="1" maxOccurs="1" name="Punto_vta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Tipo_expo" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permiso_existente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Permisos" type="tns:ArrayOfPermiso" />
+          <s:element minOccurs="1" maxOccurs="1" name="Dst_cmp" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cliente" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit_pais_cliente" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Domicilio_cliente" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Id_impositivo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Moneda_Id" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Moneda_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="CanMisMonExt" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs_comerciales" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Imp_total" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cmps_asoc" type="tns:ArrayOfCmp_asoc" />
+          <s:element minOccurs="0" maxOccurs="1" name="Forma_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Incoterms_Ds" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Idioma_cbte" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_cbte_cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fch_venc_Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cae" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Resultado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Motivos_Obs" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opcionales" type="tns:ArrayOfOpcional" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_pago" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Actividades" type="tns:ArrayOfActividad" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Cbte_Tipo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Cbte_TipoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Cbte_TipoResult" type="tns:FEXResponse_Cbte_Tipo" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Cbte_Tipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Cbte_Tipo" nillable="true" type="tns:ClsFEXResponse_Cbte_Tipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Cbte_Tipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Tipo_Expo">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_Tipo_ExpoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_Tipo_ExpoResult" type="tns:FEXResponse_Tex" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Tex" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Tex" nillable="true" type="tns:ClsFEXResponse_Tex" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Tex">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Tex_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Tex_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Incoterms">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IncotermsResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IncotermsResult" type="tns:FEXResponse_Inc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Inc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Inc" nillable="true" type="tns:ClsFEXResponse_Inc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Inc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Inc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Idiomas">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_IdiomasResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_IdiomasResult" type="tns:FEXResponse_Idi" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Idi" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Idi" nillable="true" type="tns:ClsFEXResponse_Idi" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Idi">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Idi_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Idi_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_UMed">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_UMedResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_UMedResult" type="tns:FEXResponse_Umed" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Umed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_UMed" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_UMed" nillable="true" type="tns:ClsFEXResponse_UMed" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_UMed">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Umed_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Umed_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_pais">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_paisResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_paisResult" type="tns:FEXResponse_DST_pais" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_pais" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_pais" nillable="true" type="tns:ClsFEXResponse_DST_pais" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_pais">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_DST_CUIT">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_DST_CUITResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_DST_CUITResult" type="tns:FEXResponse_DST_cuit" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_DST_cuit" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_DST_cuit" nillable="true" type="tns:ClsFEXResponse_DST_cuit" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_DST_cuit">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="DST_CUIT" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="DST_Ds" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MONResult" type="tns:FEXResponse_Mon" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon" nillable="true" type="tns:ClsFEXResponse_Mon" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACION">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Fecha_CTZ" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_MON_CON_COTIZACIONResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_MON_CON_COTIZACIONResult" type="tns:FEXResponse_Mon_CON_COTIZACION" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Mon_CON_COTIZACION">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Mon_CON_Cotizacion" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Mon_CON_Cotizacion" nillable="true" type="tns:ClsFEXResponse_Mon_CON_Cotizacion" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Mon_CON_Cotizacion">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Id" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_ctz" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Fecha_ctz" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMP">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEX_LastCMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="ClsFEX_LastCMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Token" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Sign" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cuit" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Pto_venta" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_Tipo" type="s:short" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_CMPResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_CMPResult" type="tns:FEXResponseLast_CMP" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponseLast_CMP">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResult_LastCMP" type="tns:ClsFEX_LastCMP_Response" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEX_LastCMP_Response">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Cbte_nro" type="s:long" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cbte_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXDummy">
+        <s:complexType />
+      </s:element>
+      <s:element name="FEXDummyResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXDummyResult" type="tns:DummyResponse" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="DummyResponse">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="AppServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="DbServer" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="AuthServer" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Ctz">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="Mon_id" type="s:string" />
+            <s:element minOccurs="0" maxOccurs="1" name="FchCotiz" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_CtzResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_CtzResult" type="tns:FEXResponse_Ctz" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_Ctz" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Ctz">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Mon_ctz" type="s:decimal" />
+          <s:element minOccurs="0" maxOccurs="1" name="Mon_fecha" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetLast_ID">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetLast_IDResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetLast_IDResult" type="tns:FEXResponse_LastID" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_LastID" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_LastID">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_PtoVenta">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_PtoVentaResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_PtoVentaResult" type="tns:FEXResponse_PtoVenta" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_PtoVenta" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_PtoVenta" nillable="true" type="tns:ClsFEXResponse_PtoVenta" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_PtoVenta">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Pve_Nro" type="s:int" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_Bloqueado" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Pve_FchBaja" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXCheck_Permiso">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+            <s:element minOccurs="0" maxOccurs="1" name="ID_Permiso" type="s:string" />
+            <s:element minOccurs="1" maxOccurs="1" name="Dst_merc" type="s:int" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXCheck_PermisoResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXCheck_PermisoResult" type="tns:FEXResponse_CheckPermiso" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ClsFEXResponse_CheckPermiso" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_CheckPermiso">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Status" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Opcionales">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_OpcionalesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_OpcionalesResult" type="tns:FEXResponse_Opc" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_Opc" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_Opc" nillable="true" type="tns:ClsFEXResponse_Opc" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_Opc">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Opc_Id" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_Ds" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_desde" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Opc_vig_hasta" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:element name="FEXGetPARAM_Actividades">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="Auth" type="tns:ClsFEXAuthRequest" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="FEXGetPARAM_ActividadesResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="FEXGetPARAM_ActividadesResult" type="tns:FEXResponse_Actividades" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:complexType name="FEXResponse_Actividades">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="FEXResultGet" type="tns:ArrayOfClsFEXResponse_ActividadTipo" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXErr" type="tns:ClsFEXErr" />
+          <s:element minOccurs="0" maxOccurs="1" name="FEXEvents" type="tns:ClsFEXEvents" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ArrayOfClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="ClsFEXResponse_ActividadTipo" nillable="true" type="tns:ClsFEXResponse_ActividadTipo" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="ClsFEXResponse_ActividadTipo">
+        <s:sequence>
+          <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:long" />
+          <s:element minOccurs="1" maxOccurs="1" name="Orden" type="s:short" />
+          <s:element minOccurs="0" maxOccurs="1" name="Desc" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="FEXAuthorizeSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXAuthorize" />
+  </wsdl:message>
+  <wsdl:message name="FEXAuthorizeSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXAuthorizeResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetCMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetCMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetCMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_Tipo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Cbte_TipoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Cbte_TipoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_Expo" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_Tipo_ExpoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Tipo_ExpoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Incoterms" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IncotermsSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IncotermsResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Idiomas" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_IdiomasSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_IdiomasResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMed" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_UMedSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_UMedResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_pais" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_paisSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_paisResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUIT" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_DST_CUITSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_DST_CUITResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACION" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_MON_CON_COTIZACIONSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_MON_CON_COTIZACIONResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMP" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_CMPSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_CMPResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapIn">
+    <wsdl:part name="parameters" element="tns:FEXDummy" />
+  </wsdl:message>
+  <wsdl:message name="FEXDummySoapOut">
+    <wsdl:part name="parameters" element="tns:FEXDummyResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Ctz" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_CtzSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_CtzResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_ID" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetLast_IDSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetLast_IDResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVenta" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_PtoVentaSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_PtoVentaResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXCheck_Permiso" />
+  </wsdl:message>
+  <wsdl:message name="FEXCheck_PermisoSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXCheck_PermisoResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Opcionales" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_OpcionalesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_OpcionalesResponse" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapIn">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_Actividades" />
+  </wsdl:message>
+  <wsdl:message name="FEXGetPARAM_ActividadesSoapOut">
+    <wsdl:part name="parameters" element="tns:FEXGetPARAM_ActividadesResponse" />
+  </wsdl:message>
+  <wsdl:portType name="ServiceSoap">
+    <wsdl:operation name="FEXAuthorize">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Autoriza un comprobante, devolviendo  su CAE correspondiente</wsdl:documentation>
+      <wsdl:input message="tns:FEXAuthorizeSoapIn" />
+      <wsdl:output message="tns:FEXAuthorizeSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera los datos completos de un comprobante ya autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetCMPSoapIn" />
+      <wsdl:output message="tns:FEXGetCMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de comprobante  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Cbte_TipoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Cbte_TipoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los tipos de exportacion  y sus codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_Tipo_ExpoSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_Tipo_ExpoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado Incoterms  utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IncotermsSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IncotermsSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los idiomas  y sus codigos utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_IdiomasSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_IdiomasSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las unidades de medida  y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_UMedSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_UMedSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de paises</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_paisSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_paisSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las cuits de los paises de destinacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_DST_CUITSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_DST_CUITSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas y su codigo utilizables en servicio de autorizacion</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado  de monedas que tengan cotizacion de ADUANA a una fecha determinada, utilizables en el proceso de autorizacion de comprobantes de servicios</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_MON_CON_COTIZACIONSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimos comprobante autorizado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_CMPSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_CMPSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Metodo dummy para verificacion de funcionamiento</wsdl:documentation>
+      <wsdl:input message="tns:FEXDummySoapIn" />
+      <wsdl:output message="tns:FEXDummySoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera la cotizacion de la moneda consultada y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_CtzSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_CtzSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el ultimo ID y su  fecha </wsdl:documentation>
+      <wsdl:input message="tns:FEXGetLast_IDSoapIn" />
+      <wsdl:output message="tns:FEXGetLast_IDSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de los puntos de venta registrados para Factura electronica de exportacion - WS y su estado</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_PtoVentaSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_PtoVentaSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifica la  existencia de la permiso/pais de destinación  de embarque ingresado</wsdl:documentation>
+      <wsdl:input message="tns:FEXCheck_PermisoSoapIn" />
+      <wsdl:output message="tns:FEXCheck_PermisoSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de identificadores para los campos Opcionales</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_OpcionalesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_OpcionalesSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Recupera el listado de las diferentes actividades habilitadas para el emisor</wsdl:documentation>
+      <wsdl:input message="tns:FEXGetPARAM_ActividadesSoapIn" />
+      <wsdl:output message="tns:FEXGetPARAM_ActividadesSoapOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="ServiceSoap" type="tns:ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="ServiceSoap12" type="tns:ServiceSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="FEXAuthorize">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXAuthorize" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetCMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetCMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Cbte_Tipo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Cbte_Tipo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Tipo_Expo">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Tipo_Expo" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Incoterms">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Incoterms" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Idiomas">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Idiomas" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_UMed">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_UMed" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_pais">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_pais" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_DST_CUIT">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_DST_CUIT" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_MON_CON_COTIZACION">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_MON_CON_COTIZACION" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_CMP">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_CMP" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXDummy">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXDummy" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Ctz">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Ctz" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetLast_ID">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetLast_ID" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_PtoVenta">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_PtoVenta" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXCheck_Permiso">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXCheck_Permiso" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Opcionales">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Opcionales" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="FEXGetPARAM_Actividades">
+      <soap12:operation soapAction="http://ar.gov.afip.dif.fexv1/FEXGetPARAM_Actividades" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Service">
+    <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Web Service orientado  al  servicio  de autorizacion de comprobantes de Exportacion electronicos</wsdl:documentation>
+    <wsdl:port name="ServiceSoap" binding="tns:ServiceSoap">
+      <soap:address location="https://wswhomo.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+    <wsdl:port name="ServiceSoap12" binding="tns:ServiceSoap12">
+      <soap12:address location="https://wswhomo.afip.gov.ar/wsfexv1/service.asmx" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/packages/core/src/infrastructure/outbound/ports/soap/enums/endpoints.enum.ts
+++ b/packages/core/src/infrastructure/outbound/ports/soap/enums/endpoints.enum.ts
@@ -16,6 +16,18 @@ export enum EndpointsEnum {
   WSFEV1_TEST = "https://wswhomo.afip.gov.ar/wsfev1/service.asmx",
 
   /**
+   * WS Facturacion Electronica de Exportacion
+   **/
+  WSFEX = "https://servicios1.afip.gov.ar/wsfexv1/service.asmx",
+  WSFEX_TEST = "https://wswhomo.afip.gov.ar/wsfexv1/service.asmx",
+
+  /**
+   * WS Factura de Crédito Electrónica
+   **/
+  WSFECRED = "https://serviciosjava.afip.gob.ar/wsfecred/FECredService",
+  WSFECRED_TEST = "https://fwshomo.afip.gov.ar/wsfecred/FECredService",
+
+  /**
    * WS Constancia inscripción
    **/
   WSSR_INSCRIPTION_PROOF = "https://aws.afip.gov.ar/sr-padron/webservices/personaServiceA5",

--- a/packages/core/src/infrastructure/outbound/ports/soap/enums/service-names.enum.ts
+++ b/packages/core/src/infrastructure/outbound/ports/soap/enums/service-names.enum.ts
@@ -1,6 +1,8 @@
 export enum ServiceNamesEnum {
   FE_DUMMY = "FEDummy",
   WSFE = "wsfe",
+  WSFEX = "wsfex",
+  WSFECRED = "wsfecred",
   WSSR_INSCRIPTION_PROOF = "ws_sr_constancia_inscripcion",
   WSSR_PADRON_FOUR = "ws_sr_padron_a4",
   WSSR_PADRON_FIVE = "ws_sr_padron_a5",

--- a/packages/core/src/infrastructure/outbound/ports/soap/enums/wsdl-path.enum.ts
+++ b/packages/core/src/infrastructure/outbound/ports/soap/enums/wsdl-path.enum.ts
@@ -4,6 +4,12 @@ export enum WsdlPathEnum {
   WSFE = "wsfe-production.wsdl",
   WSFE_TEST = "wsfe.wsdl",
 
+  WSFEX = "wsfex-production.wsdl",
+  WSFEX_TEST = "wsfex.wsdl",
+
+  WSFECRED = "wsfecred-production.wsdl",
+  WSFECRED_TEST = "wsfecred.wsdl",
+
   WSSR_INSCRIPTION_PROOF = "ws_sr_inscription_proof-production.wsdl",
   WSSR_INSCRIPTION_PROOF_TEST = "ws_sr_inscription_proof.wsdl",
 

--- a/packages/core/src/infrastructure/outbound/ports/soap/interfaces/FECredService/ServiceSoap.ts
+++ b/packages/core/src/infrastructure/outbound/ports/soap/interfaces/FECredService/ServiceSoap.ts
@@ -1,0 +1,191 @@
+import { Client } from "soap";
+import { SoapAsyncFunc } from "@infrastructure/types";
+
+export interface IFECredDummyInput {}
+
+export interface IFECredDummyOutput {
+  dummyReturn: {
+    appserver: string;
+    authserver: string;
+    dbserver: string;
+  };
+  dummyResponse?: {
+    dummyReturn: {
+      appserver: string;
+      authserver: string;
+      dbserver: string;
+    };
+  };
+}
+
+export interface IAceptarFECredInput extends Record<string, any> {}
+export interface IAceptarFECredOutput {
+  operacionFECredReturn?: any;
+}
+
+export interface IRechazarFECredInput extends Record<string, any> {}
+export interface IRechazarFECredOutput {
+  operacionFECredReturn?: any;
+}
+
+export interface IRechazarNotaDCInput extends Record<string, any> {}
+export interface IRechazarNotaDCOutput {
+  rechazarNotaDCReturn?: any;
+}
+
+export interface IInformarFacturaAgtDptoCltvInput extends Record<string, any> {}
+export interface IInformarFacturaAgtDptoCltvOutput {
+  operacionFECredReturn?: any;
+}
+
+export interface IInformarCancelacionTotalFECredInput extends Record<string, any> {}
+export interface IInformarCancelacionTotalFECredOutput {
+  operacionFECredReturn?: any;
+}
+
+export interface IModificarOpcionTransferenciaInput extends Record<string, any> {}
+export interface IModificarOpcionTransferenciaOutput {
+  operacionFECredReturn?: any;
+}
+
+export interface IConsultarComprobantesInput extends Record<string, any> {}
+export interface IConsultarComprobantesOutput {
+  consultarCmpReturn?: any;
+}
+
+export interface IConsultarCtaCteInput extends Record<string, any> {}
+export interface IConsultarCtaCteOutput {
+  consultarCtaCteReturn?: any;
+}
+
+export interface IConsultarCtasCtesInput extends Record<string, any> {}
+export interface IConsultarCtasCtesOutput {
+  consultarCtasCtesReturn?: any;
+}
+
+export interface IConsultarCuentasEnAgtDptoCltvInput extends Record<string, any> {}
+export interface IConsultarCuentasEnAgtDptoCltvOutput {
+  consultarCuentasEnAgtDptoCltvReturn?: any;
+}
+
+export interface IConsultarFacturasAgtDptoCltvInput extends Record<string, any> {}
+export interface IConsultarFacturasAgtDptoCltvOutput {
+  consultarFacturasAgtDptoCltvReturn?: any;
+}
+
+export interface IConsultarHistorialEstadosComprobanteInput extends Record<string, any> {}
+export interface IConsultarHistorialEstadosComprobanteOutput {
+  consultarHistorialEstadosComprobanteReturn?: any;
+}
+
+export interface IConsultarHistorialEstadosCtaCteInput extends Record<string, any> {}
+export interface IConsultarHistorialEstadosCtaCteOutput {
+  consultarHistorialEstadosCtaCteReturn?: any;
+}
+
+export interface IConsultarMontoObligadoRecepcionInput extends Record<string, any> {}
+export interface IConsultarMontoObligadoRecepcionOutput {
+  consultarMontoObligadoRecepcionReturn?: any;
+}
+
+export interface IConsultarObligadoRecepcionInput extends Record<string, any> {}
+export interface IConsultarObligadoRecepcionOutput {
+  consultarObligadoRecepcionReturn?: any;
+}
+
+export interface IConsultarTiposAjustesOperacionInput extends Record<string, any> {}
+export interface IConsultarTiposAjustesOperacionOutput {
+  codigoDescripcionReturn?: any;
+}
+
+export interface IConsultarTiposFormasCancelacionInput extends Record<string, any> {}
+export interface IConsultarTiposFormasCancelacionOutput {
+  codigoDescripcionReturn?: any;
+}
+
+export interface IConsultarTiposMotivosRechazoInput extends Record<string, any> {}
+export interface IConsultarTiposMotivosRechazoOutput {
+  codigoDescripcionReturn?: any;
+}
+
+export interface IConsultarTiposRetencionesInput extends Record<string, any> {}
+export interface IConsultarTiposRetencionesOutput {
+  consultarTiposRetencionesReturn?: any;
+}
+
+export interface IObtenerRemitosInput extends Record<string, any> {}
+export interface IObtenerRemitosOutput {
+  obtenerRemitosReturn?: any;
+}
+
+export interface IFECredServiceSoap extends Client {
+  dummyAsync: SoapAsyncFunc<IFECredDummyInput, IFECredDummyOutput>;
+  aceptarFECredAsync: SoapAsyncFunc<IAceptarFECredInput, IAceptarFECredOutput>;
+  rechazarFECredAsync: SoapAsyncFunc<IRechazarFECredInput, IRechazarFECredOutput>;
+  rechazarNotaDCAsync: SoapAsyncFunc<IRechazarNotaDCInput, IRechazarNotaDCOutput>;
+  informarFacturaAgtDptoCltvAsync: SoapAsyncFunc<
+    IInformarFacturaAgtDptoCltvInput,
+    IInformarFacturaAgtDptoCltvOutput
+  >;
+  informarCancelacionTotalFECredAsync: SoapAsyncFunc<
+    IInformarCancelacionTotalFECredInput,
+    IInformarCancelacionTotalFECredOutput
+  >;
+  modificarOpcionTransferenciaAsync: SoapAsyncFunc<
+    IModificarOpcionTransferenciaInput,
+    IModificarOpcionTransferenciaOutput
+  >;
+  consultarComprobantesAsync: SoapAsyncFunc<
+    IConsultarComprobantesInput,
+    IConsultarComprobantesOutput
+  >;
+  consultarCtaCteAsync: SoapAsyncFunc<
+    IConsultarCtaCteInput,
+    IConsultarCtaCteOutput
+  >;
+  consultarCtasCtesAsync: SoapAsyncFunc<
+    IConsultarCtasCtesInput,
+    IConsultarCtasCtesOutput
+  >;
+  consultarCuentasEnAgtDptoCltvAsync: SoapAsyncFunc<
+    IConsultarCuentasEnAgtDptoCltvInput,
+    IConsultarCuentasEnAgtDptoCltvOutput
+  >;
+  consultarFacturasAgtDptoCltvAsync: SoapAsyncFunc<
+    IConsultarFacturasAgtDptoCltvInput,
+    IConsultarFacturasAgtDptoCltvOutput
+  >;
+  consultarHistorialEstadosComprobanteAsync: SoapAsyncFunc<
+    IConsultarHistorialEstadosComprobanteInput,
+    IConsultarHistorialEstadosComprobanteOutput
+  >;
+  consultarHistorialEstadosCtaCteAsync: SoapAsyncFunc<
+    IConsultarHistorialEstadosCtaCteInput,
+    IConsultarHistorialEstadosCtaCteOutput
+  >;
+  consultarMontoObligadoRecepcionAsync: SoapAsyncFunc<
+    IConsultarMontoObligadoRecepcionInput,
+    IConsultarMontoObligadoRecepcionOutput
+  >;
+  consultarObligadoRecepcionAsync: SoapAsyncFunc<
+    IConsultarObligadoRecepcionInput,
+    IConsultarObligadoRecepcionOutput
+  >;
+  consultarTiposAjustesOperacionAsync: SoapAsyncFunc<
+    IConsultarTiposAjustesOperacionInput,
+    IConsultarTiposAjustesOperacionOutput
+  >;
+  consultarTiposFormasCancelacionAsync: SoapAsyncFunc<
+    IConsultarTiposFormasCancelacionInput,
+    IConsultarTiposFormasCancelacionOutput
+  >;
+  consultarTiposMotivosRechazoAsync: SoapAsyncFunc<
+    IConsultarTiposMotivosRechazoInput,
+    IConsultarTiposMotivosRechazoOutput
+  >;
+  consultarTiposRetencionesAsync: SoapAsyncFunc<
+    IConsultarTiposRetencionesInput,
+    IConsultarTiposRetencionesOutput
+  >;
+  obtenerRemitosAsync: SoapAsyncFunc<IObtenerRemitosInput, IObtenerRemitosOutput>;
+}

--- a/packages/core/src/infrastructure/outbound/ports/soap/interfaces/FEXService/ServiceSoap.ts
+++ b/packages/core/src/infrastructure/outbound/ports/soap/interfaces/FEXService/ServiceSoap.ts
@@ -1,0 +1,183 @@
+import { Client } from "soap";
+import { SoapAsyncFunc } from "@infrastructure/types";
+
+export interface IFEXAuthorizeInput {
+  Cmp: Record<string, any>;
+}
+
+export interface IFEXAuthorizeOutput {
+  FEXAuthorizeResult: any;
+}
+
+export interface IFEXGetCMPInput {
+  Cmp: Record<string, any>;
+}
+
+export interface IFEXGetCMPOutput {
+  FEXGetCMPResult: any;
+}
+
+export interface IFEXGetLast_CMPInput {
+  Auth: Record<string, any>;
+}
+
+export interface IFEXGetLast_CMPOutput {
+  FEXGetLast_CMPResult: any;
+}
+
+export interface IFEXGetLast_IDInput {}
+
+export interface IFEXGetLast_IDOutput {
+  FEXGetLast_IDResult: any;
+}
+
+export interface IFEXCheck_PermisoInput {
+  ID_Permiso?: string;
+  Dst_merc: number;
+}
+
+export interface IFEXCheck_PermisoOutput {
+  FEXCheck_PermisoResult: any;
+}
+
+export interface IFEXDummyInput {}
+
+export interface IFEXDummyOutput {
+  FEXDummyResult: any;
+}
+
+export interface IFEXGetPARAM_PtoVentaInput {}
+export interface IFEXGetPARAM_PtoVentaOutput {
+  FEXGetPARAM_PtoVentaResult: any;
+}
+
+export interface IFEXGetPARAM_Cbte_TipoInput {}
+export interface IFEXGetPARAM_Cbte_TipoOutput {
+  FEXGetPARAM_Cbte_TipoResult: any;
+}
+
+export interface IFEXGetPARAM_Tipo_ExpoInput {}
+export interface IFEXGetPARAM_Tipo_ExpoOutput {
+  FEXGetPARAM_Tipo_ExpoResult: any;
+}
+
+export interface IFEXGetPARAM_IncotermsInput {}
+export interface IFEXGetPARAM_IncotermsOutput {
+  FEXGetPARAM_IncotermsResult: any;
+}
+
+export interface IFEXGetPARAM_IdiomasInput {}
+export interface IFEXGetPARAM_IdiomasOutput {
+  FEXGetPARAM_IdiomasResult: any;
+}
+
+export interface IFEXGetPARAM_UMedInput {}
+export interface IFEXGetPARAM_UMedOutput {
+  FEXGetPARAM_UMedResult: any;
+}
+
+export interface IFEXGetPARAM_DST_paisInput {}
+export interface IFEXGetPARAM_DST_paisOutput {
+  FEXGetPARAM_DST_paisResult: any;
+}
+
+export interface IFEXGetPARAM_DST_CUITInput {}
+export interface IFEXGetPARAM_DST_CUITOutput {
+  FEXGetPARAM_DST_CUITResult: any;
+}
+
+export interface IFEXGetPARAM_MONInput {}
+export interface IFEXGetPARAM_MONOutput {
+  FEXGetPARAM_MONResult: any;
+}
+
+export interface IFEXGetPARAM_MON_CON_COTIZACIONInput {
+  Fecha_CTZ?: string;
+}
+
+export interface IFEXGetPARAM_MON_CON_COTIZACIONOutput {
+  FEXGetPARAM_MON_CON_COTIZACIONResult: any;
+}
+
+export interface IFEXGetPARAM_CtzInput {
+  Mon_id?: string;
+  FchCotiz?: string;
+}
+
+export interface IFEXGetPARAM_CtzOutput {
+  FEXGetPARAM_CtzResult: any;
+}
+
+export interface IFEXGetPARAM_OpcionalesInput {}
+export interface IFEXGetPARAM_OpcionalesOutput {
+  FEXGetPARAM_OpcionalesResult: any;
+}
+
+export interface IFEXGetPARAM_ActividadesInput {}
+export interface IFEXGetPARAM_ActividadesOutput {
+  FEXGetPARAM_ActividadesResult: any;
+}
+
+export interface IFEXServiceSoap extends Client {
+  FEXAuthorizeAsync: SoapAsyncFunc<IFEXAuthorizeInput, IFEXAuthorizeOutput>;
+  FEXGetCMPAsync: SoapAsyncFunc<IFEXGetCMPInput, IFEXGetCMPOutput>;
+  FEXGetLast_CMPAsync: SoapAsyncFunc<IFEXGetLast_CMPInput, IFEXGetLast_CMPOutput>;
+  FEXGetLast_IDAsync: SoapAsyncFunc<IFEXGetLast_IDInput, IFEXGetLast_IDOutput>;
+  FEXCheck_PermisoAsync: SoapAsyncFunc<
+    IFEXCheck_PermisoInput,
+    IFEXCheck_PermisoOutput
+  >;
+  FEXDummyAsync: SoapAsyncFunc<IFEXDummyInput, IFEXDummyOutput>;
+  FEXGetPARAM_PtoVentaAsync: SoapAsyncFunc<
+    IFEXGetPARAM_PtoVentaInput,
+    IFEXGetPARAM_PtoVentaOutput
+  >;
+  FEXGetPARAM_Cbte_TipoAsync: SoapAsyncFunc<
+    IFEXGetPARAM_Cbte_TipoInput,
+    IFEXGetPARAM_Cbte_TipoOutput
+  >;
+  FEXGetPARAM_Tipo_ExpoAsync: SoapAsyncFunc<
+    IFEXGetPARAM_Tipo_ExpoInput,
+    IFEXGetPARAM_Tipo_ExpoOutput
+  >;
+  FEXGetPARAM_IncotermsAsync: SoapAsyncFunc<
+    IFEXGetPARAM_IncotermsInput,
+    IFEXGetPARAM_IncotermsOutput
+  >;
+  FEXGetPARAM_IdiomasAsync: SoapAsyncFunc<
+    IFEXGetPARAM_IdiomasInput,
+    IFEXGetPARAM_IdiomasOutput
+  >;
+  FEXGetPARAM_UMedAsync: SoapAsyncFunc<
+    IFEXGetPARAM_UMedInput,
+    IFEXGetPARAM_UMedOutput
+  >;
+  FEXGetPARAM_DST_paisAsync: SoapAsyncFunc<
+    IFEXGetPARAM_DST_paisInput,
+    IFEXGetPARAM_DST_paisOutput
+  >;
+  FEXGetPARAM_DST_CUITAsync: SoapAsyncFunc<
+    IFEXGetPARAM_DST_CUITInput,
+    IFEXGetPARAM_DST_CUITOutput
+  >;
+  FEXGetPARAM_MONAsync: SoapAsyncFunc<
+    IFEXGetPARAM_MONInput,
+    IFEXGetPARAM_MONOutput
+  >;
+  FEXGetPARAM_MON_CON_COTIZACIONAsync: SoapAsyncFunc<
+    IFEXGetPARAM_MON_CON_COTIZACIONInput,
+    IFEXGetPARAM_MON_CON_COTIZACIONOutput
+  >;
+  FEXGetPARAM_CtzAsync: SoapAsyncFunc<
+    IFEXGetPARAM_CtzInput,
+    IFEXGetPARAM_CtzOutput
+  >;
+  FEXGetPARAM_OpcionalesAsync: SoapAsyncFunc<
+    IFEXGetPARAM_OpcionalesInput,
+    IFEXGetPARAM_OpcionalesOutput
+  >;
+  FEXGetPARAM_ActividadesAsync: SoapAsyncFunc<
+    IFEXGetPARAM_ActividadesInput,
+    IFEXGetPARAM_ActividadesOutput
+  >;
+}

--- a/packages/core/src/infrastructure/outbound/ports/soap/interfaces/FEXService/ServiceSoap12.ts
+++ b/packages/core/src/infrastructure/outbound/ports/soap/interfaces/FEXService/ServiceSoap12.ts
@@ -1,0 +1,183 @@
+import { Client } from "soap";
+import { SoapAsyncFunc } from "@infrastructure/types";
+
+export interface IFEXAuthorizeInput {
+  Cmp: Record<string, any>;
+}
+
+export interface IFEXAuthorizeOutput {
+  FEXAuthorizeResult: any;
+}
+
+export interface IFEXGetCMPInput {
+  Cmp: Record<string, any>;
+}
+
+export interface IFEXGetCMPOutput {
+  FEXGetCMPResult: any;
+}
+
+export interface IFEXGetLast_CMPInput {
+  Auth: Record<string, any>;
+}
+
+export interface IFEXGetLast_CMPOutput {
+  FEXGetLast_CMPResult: any;
+}
+
+export interface IFEXGetLast_IDInput {}
+
+export interface IFEXGetLast_IDOutput {
+  FEXGetLast_IDResult: any;
+}
+
+export interface IFEXCheck_PermisoInput {
+  ID_Permiso?: string;
+  Dst_merc: number;
+}
+
+export interface IFEXCheck_PermisoOutput {
+  FEXCheck_PermisoResult: any;
+}
+
+export interface IFEXDummyInput {}
+
+export interface IFEXDummyOutput {
+  FEXDummyResult: any;
+}
+
+export interface IFEXGetPARAM_PtoVentaInput {}
+export interface IFEXGetPARAM_PtoVentaOutput {
+  FEXGetPARAM_PtoVentaResult: any;
+}
+
+export interface IFEXGetPARAM_Cbte_TipoInput {}
+export interface IFEXGetPARAM_Cbte_TipoOutput {
+  FEXGetPARAM_Cbte_TipoResult: any;
+}
+
+export interface IFEXGetPARAM_Tipo_ExpoInput {}
+export interface IFEXGetPARAM_Tipo_ExpoOutput {
+  FEXGetPARAM_Tipo_ExpoResult: any;
+}
+
+export interface IFEXGetPARAM_IncotermsInput {}
+export interface IFEXGetPARAM_IncotermsOutput {
+  FEXGetPARAM_IncotermsResult: any;
+}
+
+export interface IFEXGetPARAM_IdiomasInput {}
+export interface IFEXGetPARAM_IdiomasOutput {
+  FEXGetPARAM_IdiomasResult: any;
+}
+
+export interface IFEXGetPARAM_UMedInput {}
+export interface IFEXGetPARAM_UMedOutput {
+  FEXGetPARAM_UMedResult: any;
+}
+
+export interface IFEXGetPARAM_DST_paisInput {}
+export interface IFEXGetPARAM_DST_paisOutput {
+  FEXGetPARAM_DST_paisResult: any;
+}
+
+export interface IFEXGetPARAM_DST_CUITInput {}
+export interface IFEXGetPARAM_DST_CUITOutput {
+  FEXGetPARAM_DST_CUITResult: any;
+}
+
+export interface IFEXGetPARAM_MONInput {}
+export interface IFEXGetPARAM_MONOutput {
+  FEXGetPARAM_MONResult: any;
+}
+
+export interface IFEXGetPARAM_MON_CON_COTIZACIONInput {
+  Fecha_CTZ?: string;
+}
+
+export interface IFEXGetPARAM_MON_CON_COTIZACIONOutput {
+  FEXGetPARAM_MON_CON_COTIZACIONResult: any;
+}
+
+export interface IFEXGetPARAM_CtzInput {
+  Mon_id?: string;
+  FchCotiz?: string;
+}
+
+export interface IFEXGetPARAM_CtzOutput {
+  FEXGetPARAM_CtzResult: any;
+}
+
+export interface IFEXGetPARAM_OpcionalesInput {}
+export interface IFEXGetPARAM_OpcionalesOutput {
+  FEXGetPARAM_OpcionalesResult: any;
+}
+
+export interface IFEXGetPARAM_ActividadesInput {}
+export interface IFEXGetPARAM_ActividadesOutput {
+  FEXGetPARAM_ActividadesResult: any;
+}
+
+export interface IFEXServiceSoap12 extends Client {
+  FEXAuthorizeAsync: SoapAsyncFunc<IFEXAuthorizeInput, IFEXAuthorizeOutput>;
+  FEXGetCMPAsync: SoapAsyncFunc<IFEXGetCMPInput, IFEXGetCMPOutput>;
+  FEXGetLast_CMPAsync: SoapAsyncFunc<IFEXGetLast_CMPInput, IFEXGetLast_CMPOutput>;
+  FEXGetLast_IDAsync: SoapAsyncFunc<IFEXGetLast_IDInput, IFEXGetLast_IDOutput>;
+  FEXCheck_PermisoAsync: SoapAsyncFunc<
+    IFEXCheck_PermisoInput,
+    IFEXCheck_PermisoOutput
+  >;
+  FEXDummyAsync: SoapAsyncFunc<IFEXDummyInput, IFEXDummyOutput>;
+  FEXGetPARAM_PtoVentaAsync: SoapAsyncFunc<
+    IFEXGetPARAM_PtoVentaInput,
+    IFEXGetPARAM_PtoVentaOutput
+  >;
+  FEXGetPARAM_Cbte_TipoAsync: SoapAsyncFunc<
+    IFEXGetPARAM_Cbte_TipoInput,
+    IFEXGetPARAM_Cbte_TipoOutput
+  >;
+  FEXGetPARAM_Tipo_ExpoAsync: SoapAsyncFunc<
+    IFEXGetPARAM_Tipo_ExpoInput,
+    IFEXGetPARAM_Tipo_ExpoOutput
+  >;
+  FEXGetPARAM_IncotermsAsync: SoapAsyncFunc<
+    IFEXGetPARAM_IncotermsInput,
+    IFEXGetPARAM_IncotermsOutput
+  >;
+  FEXGetPARAM_IdiomasAsync: SoapAsyncFunc<
+    IFEXGetPARAM_IdiomasInput,
+    IFEXGetPARAM_IdiomasOutput
+  >;
+  FEXGetPARAM_UMedAsync: SoapAsyncFunc<
+    IFEXGetPARAM_UMedInput,
+    IFEXGetPARAM_UMedOutput
+  >;
+  FEXGetPARAM_DST_paisAsync: SoapAsyncFunc<
+    IFEXGetPARAM_DST_paisInput,
+    IFEXGetPARAM_DST_paisOutput
+  >;
+  FEXGetPARAM_DST_CUITAsync: SoapAsyncFunc<
+    IFEXGetPARAM_DST_CUITInput,
+    IFEXGetPARAM_DST_CUITOutput
+  >;
+  FEXGetPARAM_MONAsync: SoapAsyncFunc<
+    IFEXGetPARAM_MONInput,
+    IFEXGetPARAM_MONOutput
+  >;
+  FEXGetPARAM_MON_CON_COTIZACIONAsync: SoapAsyncFunc<
+    IFEXGetPARAM_MON_CON_COTIZACIONInput,
+    IFEXGetPARAM_MON_CON_COTIZACIONOutput
+  >;
+  FEXGetPARAM_CtzAsync: SoapAsyncFunc<
+    IFEXGetPARAM_CtzInput,
+    IFEXGetPARAM_CtzOutput
+  >;
+  FEXGetPARAM_OpcionalesAsync: SoapAsyncFunc<
+    IFEXGetPARAM_OpcionalesInput,
+    IFEXGetPARAM_OpcionalesOutput
+  >;
+  FEXGetPARAM_ActividadesAsync: SoapAsyncFunc<
+    IFEXGetPARAM_ActividadesInput,
+    IFEXGetPARAM_ActividadesOutput
+  >;
+}

--- a/packages/core/src/infrastructure/outbound/ports/soap/interfaces/index.ts
+++ b/packages/core/src/infrastructure/outbound/ports/soap/interfaces/index.ts
@@ -13,5 +13,8 @@ export * as PersonaServiceA13 from "./PersonaServiceA13/PersonaServiceA13Port";
 export * as PersonaServiceA4 from "./PersonaServiceA4/PersonaServiceA4Port";
 export * as PersonaServiceA5 from "./PersonaServiceA5/PersonaServiceA5Port";
 export * as PersonaServiceInscriptionProof from "./PersonaServiceInscriptionProof/PersonaServiceInscriptionProofPort";
+export * as FECredServiceSoap from "./FECredService/ServiceSoap";
+export * as FEXServiceSoap from "./FEXService/ServiceSoap";
+export * as FEXServiceSoap12 from "./FEXService/ServiceSoap12";
 export * as ServiceSoapTypes from "./Service/ServiceSoap";
 export * as ServiceSoap12Types from "./Service/ServiceSoap12";

--- a/packages/core/tests/unit/application/services/wsfecred.service.test.ts
+++ b/packages/core/tests/unit/application/services/wsfecred.service.test.ts
@@ -1,0 +1,91 @@
+import { WsfecredService } from "@arcasdk/core/src/application/services/wsfecred.service";
+import { IWsfecredRepositoryPort } from "@arcasdk/core/src/application/ports/fecred/fecred-repository.port";
+
+describe("WsfecredService", () => {
+  let service: WsfecredService;
+  let repository: jest.Mocked<IWsfecredRepositoryPort>;
+
+  beforeEach(() => {
+    repository = {
+      getServerStatus: jest.fn(),
+      aceptarFECred: jest.fn(),
+      rechazarFECred: jest.fn(),
+      rechazarNotaDC: jest.fn(),
+      informarFacturaAgtDptoCltv: jest.fn(),
+      informarCancelacionTotalFECred: jest.fn(),
+      modificarOpcionTransferencia: jest.fn(),
+      consultarComprobantes: jest.fn(),
+      consultarCtaCte: jest.fn(),
+      consultarCtasCtes: jest.fn(),
+      consultarCuentasEnAgtDptoCltv: jest.fn(),
+      consultarFacturasAgtDptoCltv: jest.fn(),
+      consultarHistorialEstadosComprobante: jest.fn(),
+      consultarHistorialEstadosCtaCte: jest.fn(),
+      consultarMontoObligadoRecepcion: jest.fn(),
+      consultarObligadoRecepcion: jest.fn(),
+      consultarTiposAjustesOperacion: jest.fn(),
+      consultarTiposFormasCancelacion: jest.fn(),
+      consultarTiposMotivosRechazo: jest.fn(),
+      consultarTiposRetenciones: jest.fn(),
+      obtenerRemitos: jest.fn(),
+    };
+
+    service = new WsfecredService(repository);
+  });
+
+  it("should return server status", async () => {
+    repository.getServerStatus.mockResolvedValue({
+      appserver: "OK",
+      dbserver: "OK",
+      authserver: "OK",
+    });
+
+    const result = await service.getServerStatus();
+
+    expect(repository.getServerStatus).toHaveBeenCalled();
+    expect(result).toEqual({
+      appserver: "OK",
+      dbserver: "OK",
+      authserver: "OK",
+    });
+  });
+
+  it("should accept a FECred invoice", async () => {
+    const params = { idCtaCte: 123456 };
+    repository.aceptarFECred.mockResolvedValue({ resultado: "A" } as any);
+
+    const result = await service.aceptarFECred(params);
+
+    expect(repository.aceptarFECred).toHaveBeenCalledWith(params);
+    expect(result).toEqual({ resultado: "A" });
+  });
+
+  it("should consult comprobantes", async () => {
+    const params = { rolCUITRepresentada: "COMPRADOR", nroPagina: 1 };
+    repository.consultarComprobantes.mockResolvedValue({} as any);
+
+    await service.consultarComprobantes(params);
+
+    expect(repository.consultarComprobantes).toHaveBeenCalledWith(params);
+  });
+
+  it("should fetch rejection reasons", async () => {
+    const params = { rolCUITRepresentada: "COMPRADOR" };
+    repository.consultarTiposMotivosRechazo.mockResolvedValue({} as any);
+
+    await service.consultarTiposMotivosRechazo(params);
+
+    expect(repository.consultarTiposMotivosRechazo).toHaveBeenCalledWith(params);
+  });
+
+  it("should use consultarMontoObligadoRecepcion for legacy consultarObligadoRecepcion", async () => {
+    const params = { cuitConsultada: 20210861220, importeComprobante: 1000 };
+    repository.consultarMontoObligadoRecepcion.mockResolvedValue({} as any);
+
+    await service.consultarObligadoRecepcion(params as any);
+
+    expect(repository.consultarMontoObligadoRecepcion).toHaveBeenCalledWith(
+      params
+    );
+  });
+});

--- a/packages/core/tests/unit/application/services/wsfex.service.test.ts
+++ b/packages/core/tests/unit/application/services/wsfex.service.test.ts
@@ -1,0 +1,78 @@
+import { WsfexService } from "@arcasdk/core/src/application/services/wsfex.service";
+import { IWsfexRepositoryPort } from "@arcasdk/core/src/application/ports/fex/fex-repository.port";
+
+describe("WsfexService", () => {
+  let service: WsfexService;
+  let repository: jest.Mocked<IWsfexRepositoryPort>;
+
+  beforeEach(() => {
+    repository = {
+      getServerStatus: jest.fn(),
+      authorize: jest.fn(),
+      getCmp: jest.fn(),
+      getLastCmp: jest.fn(),
+      getLastId: jest.fn(),
+      checkPermiso: jest.fn(),
+      getParamPtoVenta: jest.fn(),
+      getParamCbteTipo: jest.fn(),
+      getParamTipoExpo: jest.fn(),
+      getParamIncoterms: jest.fn(),
+      getParamIdiomas: jest.fn(),
+      getParamUmed: jest.fn(),
+      getParamDstPais: jest.fn(),
+      getParamDstCuit: jest.fn(),
+      getParamMon: jest.fn(),
+      getParamMonCotizacion: jest.fn(),
+      getParamCtz: jest.fn(),
+      getParamOpcionales: jest.fn(),
+      getParamActividades: jest.fn(),
+    };
+
+    service = new WsfexService(repository);
+  });
+
+  it("should return server status", async () => {
+    repository.getServerStatus.mockResolvedValue({
+      appserver: "OK",
+      dbserver: "OK",
+      authserver: "OK",
+    });
+
+    const result = await service.getServerStatus();
+
+    expect(repository.getServerStatus).toHaveBeenCalled();
+    expect(result).toEqual({
+      appserver: "OK",
+      dbserver: "OK",
+      authserver: "OK",
+    });
+  });
+
+  it("should authorize export voucher", async () => {
+    const cmp = { Cbte_tipo: 19 };
+    repository.authorize.mockResolvedValue({ Resultado: "A" } as any);
+
+    const result = await service.authorize(cmp);
+
+    expect(repository.authorize).toHaveBeenCalledWith(cmp);
+    expect(result).toEqual({ Resultado: "A" });
+  });
+
+  it("should get export voucher data", async () => {
+    const params = { Cbte_tipo: 19, Punto_vta: 1, Cbte_nro: 100 };
+    repository.getCmp.mockResolvedValue({} as any);
+
+    await service.getCmp(params);
+
+    expect(repository.getCmp).toHaveBeenCalledWith(params);
+  });
+
+  it("should get currency quotation", async () => {
+    const params = { Mon_id: "USD" };
+    repository.getParamCtz.mockResolvedValue({} as any);
+
+    await service.getParamCtz(params);
+
+    expect(repository.getParamCtz).toHaveBeenCalledWith(params);
+  });
+});

--- a/packages/core/tests/unit/arca.test.ts
+++ b/packages/core/tests/unit/arca.test.ts
@@ -5,12 +5,16 @@ import { FileSystemTicketStorage } from "@arcasdk/core/src/infrastructure/outbou
 import { AuthRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/auth/auth.repository";
 import { WinstonLogger } from "@arcasdk/core/src/infrastructure/outbound/adapters/logger/winston-logger";
 import { ElectronicBillingRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/electronic-billing/electronic-billing-repository";
+import { WsfecredRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/fecred/fecred-repository";
+import { WsfexRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/fex/fex-repository";
 import { RegisterScopeFourRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/register/register-scope-four.repository";
 import { RegisterScopeFiveRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/register/register-scope-five.repository";
 import { RegisterScopeTenRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/register/register-scope-ten.repository";
 import { RegisterScopeThirteenRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/register/register-scope-thirteen.repository";
 import { RegisterInscriptionProofRepository } from "@arcasdk/core/src/infrastructure/outbound/adapters/register/register-inscription-proof.repository";
 import { ElectronicBillingService } from "@arcasdk/core/src/application/services/electronic-billing.service";
+import { WsfecredService } from "@arcasdk/core/src/application/services/wsfecred.service";
+import { WsfexService } from "@arcasdk/core/src/application/services/wsfex.service";
 import { RegisterInscriptionProofService } from "@arcasdk/core/src/application/services/register-inscription-proof.service";
 import { RegisterScopeFourService } from "@arcasdk/core/src/application/services/register-scope-four.service";
 import { RegisterScopeFiveService } from "@arcasdk/core/src/application/services/register-scope-five.service";
@@ -30,6 +34,12 @@ jest.mock(
   "@arcasdk/core/src/infrastructure/outbound/adapters/electronic-billing/electronic-billing-repository"
 );
 jest.mock(
+  "@arcasdk/core/src/infrastructure/outbound/adapters/fecred/fecred-repository"
+);
+jest.mock(
+  "@arcasdk/core/src/infrastructure/outbound/adapters/fex/fex-repository"
+);
+jest.mock(
   "@arcasdk/core/src/infrastructure/outbound/adapters/register/register-scope-four.repository"
 );
 jest.mock(
@@ -45,6 +55,8 @@ jest.mock(
   "@arcasdk/core/src/infrastructure/outbound/adapters/register/register-inscription-proof.repository"
 );
 jest.mock("@arcasdk/core/src/application/services/electronic-billing.service");
+jest.mock("@arcasdk/core/src/application/services/wsfecred.service");
+jest.mock("@arcasdk/core/src/application/services/wsfex.service");
 jest.mock(
   "@arcasdk/core/src/application/services/register-inscription-proof.service"
 );
@@ -70,6 +82,8 @@ describe("Arca", () => {
     (AuthRepository as jest.Mock).mockImplementation(() => ({}));
     (WinstonLogger as jest.Mock).mockImplementation(() => ({}));
     (ElectronicBillingRepository as jest.Mock).mockImplementation(() => ({}));
+    (WsfecredRepository as jest.Mock).mockImplementation(() => ({}));
+    (WsfexRepository as jest.Mock).mockImplementation(() => ({}));
     (RegisterScopeFourRepository as jest.Mock).mockImplementation(() => ({}));
     (RegisterScopeFiveRepository as jest.Mock).mockImplementation(() => ({}));
     (RegisterScopeTenRepository as jest.Mock).mockImplementation(() => ({}));
@@ -80,6 +94,8 @@ describe("Arca", () => {
       () => ({})
     );
     (ElectronicBillingService as jest.Mock).mockImplementation(() => ({}));
+    (WsfecredService as jest.Mock).mockImplementation(() => ({}));
+    (WsfexService as jest.Mock).mockImplementation(() => ({}));
     (RegisterInscriptionProofService as jest.Mock).mockImplementation(
       () => ({})
     );
@@ -98,12 +114,16 @@ describe("Arca", () => {
       expect(AuthRepository).toHaveBeenCalled();
       expect(WinstonLogger).toHaveBeenCalled();
       expect(ElectronicBillingRepository).toHaveBeenCalled();
+      expect(WsfecredRepository).toHaveBeenCalled();
+      expect(WsfexRepository).toHaveBeenCalled();
       expect(RegisterScopeFourRepository).toHaveBeenCalled();
       expect(RegisterScopeFiveRepository).toHaveBeenCalled();
       expect(RegisterScopeTenRepository).toHaveBeenCalled();
       expect(RegisterScopeThirteenRepository).toHaveBeenCalled();
       expect(RegisterInscriptionProofRepository).toHaveBeenCalled();
       expect(ElectronicBillingService).toHaveBeenCalled();
+      expect(WsfecredService).toHaveBeenCalled();
+      expect(WsfexService).toHaveBeenCalled();
       expect(RegisterInscriptionProofService).toHaveBeenCalled();
       expect(RegisterScopeFourService).toHaveBeenCalled();
       expect(RegisterScopeFiveService).toHaveBeenCalled();
@@ -260,6 +280,15 @@ describe("Arca", () => {
         useSoap12: false,
         useHttpsAgent: false,
       });
+
+      expect(WsfexRepository).toHaveBeenCalledWith({
+        authRepository: expect.anything(),
+        logger: expect.anything(),
+        cuit: mockContext.cuit,
+        production: false,
+        useSoap12: false,
+        useHttpsAgent: false,
+      });
     });
 
     it("should create Register Repositories with correct parameters", () => {
@@ -296,6 +325,7 @@ describe("Arca", () => {
       const mockRegisterScopeTenRepository = {} as any;
       const mockRegisterScopeThirteenRepository = {} as any;
       const mockRegisterInscriptionProofRepository = {} as any;
+      const mockWsfexRepository = {} as any;
 
       (RegisterScopeFourRepository as jest.Mock).mockReturnValue(
         mockRegisterScopeFourRepository
@@ -312,6 +342,7 @@ describe("Arca", () => {
       (RegisterInscriptionProofRepository as jest.Mock).mockReturnValue(
         mockRegisterInscriptionProofRepository
       );
+      (WsfexRepository as jest.Mock).mockReturnValue(mockWsfexRepository);
 
       new Arca(mockContext);
 
@@ -330,6 +361,7 @@ describe("Arca", () => {
       expect(RegisterInscriptionProofService).toHaveBeenCalledWith(
         mockRegisterInscriptionProofRepository
       );
+      expect(WsfexService).toHaveBeenCalledWith(mockWsfexRepository);
     });
 
     it("should create ElectronicBillingService with ElectronicBillingRepository", () => {
@@ -343,6 +375,15 @@ describe("Arca", () => {
       expect(ElectronicBillingService).toHaveBeenCalledWith(
         mockElectronicBillingRepository
       );
+    });
+
+    it("should create WsfexService with WsfexRepository", () => {
+      const mockWsfexRepository = {} as any;
+      (WsfexRepository as jest.Mock).mockReturnValue(mockWsfexRepository);
+
+      new Arca(mockContext);
+
+      expect(WsfexService).toHaveBeenCalledWith(mockWsfexRepository);
     });
 
     it("should create Arca instance with production true", () => {
@@ -369,6 +410,11 @@ describe("Arca", () => {
           production: true,
         })
       );
+      expect(WsfexRepository).toHaveBeenCalledWith(
+        expect.objectContaining({
+          production: true,
+        })
+      );
       expect(RegisterScopeFourRepository).toHaveBeenCalledWith(
         expect.objectContaining({
           production: true,
@@ -380,6 +426,7 @@ describe("Arca", () => {
   describe("getters", () => {
     let arca: Arca;
     let mockElectronicBillingService: jest.Mocked<ElectronicBillingService>;
+    let mockWsfexService: jest.Mocked<WsfexService>;
     let mockRegisterInscriptionProofService: jest.Mocked<RegisterInscriptionProofService>;
     let mockRegisterScopeFourService: jest.Mocked<RegisterScopeFourService>;
     let mockRegisterScopeFiveService: jest.Mocked<RegisterScopeFiveService>;
@@ -390,6 +437,7 @@ describe("Arca", () => {
       // Setup mock services
       mockElectronicBillingService =
         {} as jest.Mocked<ElectronicBillingService>;
+      mockWsfexService = {} as jest.Mocked<WsfexService>;
       mockRegisterInscriptionProofService =
         {} as jest.Mocked<RegisterInscriptionProofService>;
       mockRegisterScopeFourService =
@@ -403,6 +451,7 @@ describe("Arca", () => {
       (ElectronicBillingService as jest.Mock).mockReturnValue(
         mockElectronicBillingService
       );
+      (WsfexService as jest.Mock).mockReturnValue(mockWsfexService);
       (RegisterInscriptionProofService as jest.Mock).mockReturnValue(
         mockRegisterInscriptionProofService
       );
@@ -424,6 +473,10 @@ describe("Arca", () => {
 
     it("should return electronicBillingService", () => {
       expect(arca.electronicBillingService).toBe(mockElectronicBillingService);
+    });
+
+    it("should return wsfexService", () => {
+      expect(arca.wsfexService).toBe(mockWsfexService);
     });
 
     it("should return registerInscriptionProofService", () => {
@@ -456,8 +509,8 @@ describe("Arca", () => {
       new Arca(mockContext);
 
       expect(FileSystemTicketStorage).toHaveBeenCalledWith({
-        ticketPath: expect.stringContaining(
-          "infrastructure/storage/auth/tickets"
+        ticketPath: expect.stringMatching(
+          /infrastructure[\\/]+storage[\\/]+auth[\\/]+tickets/
         ),
         cuit: mockContext.cuit,
         production: false,

--- a/packages/core/tests/unit/infrastructure/outbound/adapters/fecred/fecred-repository.test.ts
+++ b/packages/core/tests/unit/infrastructure/outbound/adapters/fecred/fecred-repository.test.ts
@@ -1,0 +1,87 @@
+import { WsfecredRepository } from "@infrastructure/outbound/adapters/fecred/fecred-repository";
+import { SoapClientFacade } from "@infrastructure/outbound/adapters/soap/soap-client-facade";
+import { BaseSoapRepositoryConstructorConfig } from "@infrastructure/outbound/ports/soap/soap-repository.types";
+
+jest.mock("@infrastructure/outbound/adapters/soap/soap-client-facade");
+
+describe("WsfecredRepository", () => {
+  let repository: WsfecredRepository;
+  let mockSoapClient: any;
+  let mockConfig: BaseSoapRepositoryConstructorConfig;
+
+  beforeEach(() => {
+    mockSoapClient = {
+      dummyAsync: jest.fn(),
+      consultarComprobantesAsync: jest.fn(),
+      describe: jest.fn().mockReturnValue({}),
+    };
+
+    (SoapClientFacade.create as jest.Mock).mockResolvedValue(mockSoapClient);
+
+    mockConfig = {
+      authRepository: {
+        login: jest.fn().mockResolvedValue({}),
+        getAuthParams: jest.fn().mockReturnValue({
+          Auth: { Token: "token", Sign: "sign", Cuit: 12345678901 },
+        }),
+      } as any,
+      cuit: 12345678901,
+      logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+      } as any,
+      useSoap12: false,
+    } as any;
+
+    repository = new WsfecredRepository(mockConfig);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return server status", async () => {
+    mockSoapClient.dummyAsync.mockResolvedValue([
+      {
+        dummyReturn: {
+          appserver: "OK",
+          dbserver: "OK",
+          authserver: "OK",
+        },
+      },
+    ]);
+
+    const result = await repository.getServerStatus();
+
+    expect(result).toEqual({
+      appserver: "OK",
+      dbserver: "OK",
+      authserver: "OK",
+    });
+  });
+
+  it("should inject authRequest for consultarComprobantes", async () => {
+    mockSoapClient.consultarComprobantesAsync.mockResolvedValue([
+      {
+        consultarCmpReturn: {},
+      },
+    ]);
+
+    await repository.consultarComprobantes({
+      rolCUITRepresentada: "COMPRADOR",
+      nroPagina: 1,
+    });
+
+    expect(mockSoapClient.consultarComprobantesAsync).toHaveBeenCalledWith({
+      authRequest: {
+        token: "token",
+        sign: "sign",
+        cuitRepresentada: 12345678901,
+      },
+      rolCUITRepresentada: "COMPRADOR",
+      nroPagina: 1,
+    });
+  });
+});

--- a/packages/core/tests/unit/infrastructure/outbound/adapters/fex/fex-repository.test.ts
+++ b/packages/core/tests/unit/infrastructure/outbound/adapters/fex/fex-repository.test.ts
@@ -1,0 +1,91 @@
+import { WsfexRepository } from "@infrastructure/outbound/adapters/fex/fex-repository";
+import { SoapClientFacade } from "@infrastructure/outbound/adapters/soap/soap-client-facade";
+import { BaseSoapRepositoryConstructorConfig } from "@infrastructure/outbound/ports/soap/soap-repository.types";
+
+jest.mock("@infrastructure/outbound/adapters/soap/soap-client-facade");
+
+describe("WsfexRepository", () => {
+  let repository: WsfexRepository;
+  let mockSoapClient: any;
+  let mockConfig: BaseSoapRepositoryConstructorConfig;
+
+  beforeEach(() => {
+    mockSoapClient = {
+      FEXDummyAsync: jest.fn(),
+      FEXGetLast_CMPAsync: jest.fn(),
+      describe: jest.fn().mockReturnValue({
+        Service: {
+          ServiceSoap: {
+            FEXDummy: { input: {} },
+            FEXGetLast_CMP: { input: { Auth: {} } },
+          },
+        },
+      }),
+    };
+
+    (SoapClientFacade.create as jest.Mock).mockResolvedValue(mockSoapClient);
+
+    mockConfig = {
+      authRepository: {
+        login: jest.fn().mockResolvedValue({}),
+        getAuthParams: jest.fn().mockReturnValue({
+          Auth: { Token: "token", Sign: "sign", Cuit: 12345678901 },
+        }),
+      } as any,
+      cuit: 12345678901,
+      logger: {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+      } as any,
+      useSoap12: false,
+    } as any;
+
+    repository = new WsfexRepository(mockConfig);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return server status", async () => {
+    mockSoapClient.FEXDummyAsync.mockResolvedValue([
+      {
+        FEXDummyResult: {
+          AppServer: "OK",
+          DbServer: "OK",
+          AuthServer: "OK",
+        },
+      },
+    ]);
+
+    const result = await repository.getServerStatus();
+
+    expect(result).toEqual({
+      appserver: "OK",
+      dbserver: "OK",
+      authserver: "OK",
+    });
+  });
+
+  it("should inject auth for getLastCmp", async () => {
+    mockSoapClient.FEXGetLast_CMPAsync.mockResolvedValue([
+      {
+        FEXGetLast_CMPResult: {},
+      },
+    ]);
+
+    await repository.getLastCmp({ Pto_venta: 1, Cbte_Tipo: 19 });
+
+    expect(mockSoapClient.FEXGetLast_CMPAsync).toHaveBeenCalledWith({
+      Auth: {
+        Token: "token",
+        Sign: "sign",
+        Cuit: 12345678901,
+        Pto_venta: 1,
+        Cbte_Tipo: 19,
+      },
+    });
+  });
+});


### PR DESCRIPTION
Este PR agrega soporte completo para los servicios AFIP/ARCA WSFEX (Factura de Exportación) y WSFEcred (Factura de Crédito Electrónica).
Incluye WSDLs, enums, repositorios SOAP, puertos de aplicación, servicios, wiring en Arca, documentación y tests unitarios.

Detalle de cambios:

1) WSFEX
- Nuevos WSDLs: wsfex.wsdl (test) y wsfex-production.wsdl (prod)
- Enums: endpoints, serviceName y wsdlPath
- Repositorio SOAP: WsfexRepository
- Servicio de aplicación: WsfexService
- DTOs y ports en application
- Wiring en Arca: arca.wsfexService
- Tests unitarios: servicio y repositorio

2) WSFEcred
- Nuevos WSDLs: wsfecred.wsdl (test) y wsfecred-production.wsdl (prod)
- Enums: endpoints, serviceName y wsdlPath
- Repositorio SOAP: WsfecredRepository
- Servicio de aplicación: WsfecredService
- DTOs y ports en application
- Wiring en Arca: arca.wsfecredService
- Tests unitarios: servicio y repositorio

3) Documentación
- Nueva guía: docs/services/facturacion_credito_electronica.md
- Sidebar actualizado: docs/.vitepress/config.mts
- Home actualizado: docs/index.md
- Página de exportación validada: docs/services/facturacion_exportacion.md

4) Infraestructura SOAP
- Nuevas interfaces SOAP: FECredService/ServiceSoap.ts
- wsdl-strings.ts regenerado con nuevos WSDLs

Pruebas ejecutadas:
- npm test
  - 28 suites passed, 2 skipped
  - 2 skipped por falta de certificados reales (integration tests)
- Tests unitarios agregados:
  - wsfecred.service.test.ts
  - fecred-repository.test.ts
  - wsfex.service.test.ts
  - fex-repository.test.ts
  - arca.test.ts (ajuste path Windows)

Notas:
- consultarObligadoRecepcion devuelve observación de método deprecado según WSFEcred (respuesta del servicio).