### PR TITLE
fix(ci): use strict conventional commit format for BREAKING CHANGE de…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,12 @@ jobs:
             BASE_COMMIT="$LAST_TAG"
           fi
 
-          FEAT_COUNT=$(git log "$BASE_COMMIT"..HEAD --pretty=format:"%s" 2>/dev/null | grep -c "^feat" || true)
-          FIX_COUNT=$(git log  "$BASE_COMMIT"..HEAD --pretty=format:"%s" 2>/dev/null | grep -c "^fix"  || true)
-          BREAKING=$(git log  "$BASE_COMMIT"..HEAD --pretty=format:"%b" 2>/dev/null | grep -c "BREAKING CHANGE" || true)
+          FEAT_COUNT=$(git log "$BASE_COMMIT"..HEAD --pretty=format:"%s" 2>/dev/null | grep -cE "^feat(\([^)]+\))?[!:]" || true)
+          FIX_COUNT=$(git log  "$BASE_COMMIT"..HEAD --pretty=format:"%s" 2>/dev/null | grep -cE "^fix(\([^)]+\))?[!:]"  || true)
+          # Match only conventional commit footer or ! in subject — not arbitrary text mentioning "BREAKING CHANGE"
+          BREAKING_FOOTER=$(git log "$BASE_COMMIT"..HEAD --pretty=format:"%b" 2>/dev/null | grep -cE "^BREAKING[ -]CHANGE:" || true)
+          BREAKING_SUBJECT=$(git log "$BASE_COMMIT"..HEAD --pretty=format:"%s" 2>/dev/null | grep -cE "^[a-z]+(\([^)]+\))?!:" || true)
+          BREAKING=$((BREAKING_FOOTER + BREAKING_SUBJECT))
 
           if [ "$FEAT_COUNT" -gt 0 ] || [ "$FIX_COUNT" -gt 0 ] || [ "$BREAKING" -gt 0 ]; then
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"


### PR DESCRIPTION
…tection

grep -c matched text in commit body that mentioned the string as docs, incorrectly bumping 0.3.6 to 1.0.0.

Now uses regex anchored to start of line (footer format) or type! in subject.

 All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally before submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

