### PR TITLE
fix(ci): split nx release for protected branch compatibility

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -103,18 +103,80 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Release & Publish
+      - name: Calculate versions
+        run: |
+          PACKAGE="${{ inputs.package }}"
+          echo "📦 Calculating versions from conventional commits..."
+          if [ "$PACKAGE" == "all" ]; then
+            npx nx release version --yes
+          else
+            npx nx release version --yes --projects="$PACKAGE"
+          fi
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Publish to NPM
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: |
           PACKAGE="${{ inputs.package }}"
-          echo "🚀 Versioning, changelog & publishing to NPM..."
+          echo "🚀 Publishing to NPM..."
           if [ "$PACKAGE" == "all" ]; then
-            npx nx release --yes
+            npx nx release publish --yes
           else
-            npx nx release --projects="$PACKAGE" --yes
+            npx nx release publish --yes --projects="$PACKAGE"
+          fi
+
+      - name: Create and push tags
+        run: |
+          PACKAGE="${{ inputs.package }}"
+          create_and_push_tag() {
+            local PROJECT=$1 PKG_DIR=$2
+            local VERSION TAG
+            VERSION=$(node -p "require('./${PKG_DIR}/package.json').version")
+            TAG="${PROJECT}@${VERSION}"
+            if git rev-parse "$TAG" >/dev/null 2>&1; then
+              echo "Tag $TAG already exists, skipping"
+            else
+              git tag "$TAG"
+              git push origin "$TAG"
+              echo "✅ Created and pushed tag $TAG"
+            fi
+          }
+          if [ "$PACKAGE" == "all" ] || [ "$PACKAGE" == "core" ]; then
+            create_and_push_tag "core" "packages/core"
+          fi
+          if [ "$PACKAGE" == "all" ] || [ "$PACKAGE" == "pdf" ]; then
+            create_and_push_tag "pdf" "packages/pdf"
+          fi
+
+      - name: Create GitHub Releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE="${{ inputs.package }}"
+          create_release() {
+            local PROJECT=$1 PKG_DIR=$2
+            local VERSION TAG
+            VERSION=$(node -p "require('./${PKG_DIR}/package.json').version")
+            TAG="${PROJECT}@${VERSION}"
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "Release $TAG already exists, skipping"
+            else
+              gh release create "$TAG" \
+                --title "@arcasdk/${PROJECT} ${VERSION}" \
+                --generate-notes \
+                --latest
+              echo "✅ Created GitHub release $TAG"
+            fi
+          }
+          if [ "$PACKAGE" == "all" ] || [ "$PACKAGE" == "core" ]; then
+            create_release "core" "packages/core"
+          fi
+          if [ "$PACKAGE" == "all" ] || [ "$PACKAGE" == "pdf" ]; then
+            create_release "pdf" "packages/pdf"
           fi
 
       - name: Publish Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release & Documentation
+name: CI & Documentation
 
 on:
   push:
@@ -7,27 +7,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  contents: read
 
 jobs:
-  release:
-    name: Calculate Version & Release
+  build:
+    name: Build & Validate
     runs-on: ubuntu-latest
     env:
       NX_DAEMON: "false"
-    outputs:
-      core_version: ${{ steps.core_version.outputs.version }}
-      core_published: ${{ steps.core_version.outputs.published }}
-      pdf_version: ${{ steps.pdf_version.outputs.version }}
-      pdf_published: ${{ steps.pdf_version.outputs.published }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -54,176 +46,14 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Setup Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Calculate core version
-        id: core_version
-        run: |
-          LAST_TAG=$(git tag -l 'core@*' --sort=-v:refname | head -n1 || echo "")
-          CURRENT_VERSION=$(node -p "require('./packages/core/package.json').version")
-
-          if [ -z "$LAST_TAG" ]; then
-            BASE_COMMIT="$(git rev-list --max-parents=0 HEAD)"
-          else
-            BASE_COMMIT="$LAST_TAG"
-          fi
-
-          COMMITS=$(git log "$BASE_COMMIT"..HEAD --pretty=format:"%H" -- packages/core/)
-          FEAT_COUNT=0; FIX_COUNT=0; BREAKING=0
-          for SHA in $COMMITS; do
-            SUBJECT=$(git log -1 --pretty=format:"%s" "$SHA")
-            BODY=$(git log -1 --pretty=format:"%b" "$SHA")
-            echo "$SUBJECT" | grep -qE "^feat(\([^)]+\))?[!:]" && FEAT_COUNT=$((FEAT_COUNT + 1))
-            echo "$SUBJECT" | grep -qE "^fix(\([^)]+\))?[!:]"  && FIX_COUNT=$((FIX_COUNT + 1))
-            echo "$BODY"    | grep -qE "^BREAKING[ -]CHANGE:"   && BREAKING=$((BREAKING + 1))
-            echo "$SUBJECT" | grep -qE "^[a-z]+(\([^)]+\))?!:"  && BREAKING=$((BREAKING + 1))
-          done
-
-          if [ "$FEAT_COUNT" -gt 0 ] || [ "$FIX_COUNT" -gt 0 ] || [ "$BREAKING" -gt 0 ]; then
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-            if [ "$BREAKING" -gt 0 ]; then
-              NEW_VERSION="$((MAJOR + 1)).0.0"
-            elif [ "$FEAT_COUNT" -gt 0 ]; then
-              NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
-            else
-              NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
-            fi
-            echo "published=true"       >> $GITHUB_OUTPUT
-            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-            echo "tag=core@$NEW_VERSION" >> $GITHUB_OUTPUT
-            echo "Core: v$NEW_VERSION (feat=$FEAT_COUNT fix=$FIX_COUNT breaking=$BREAKING)"
-          else
-            echo "published=false" >> $GITHUB_OUTPUT
-            echo "Core: no changes detected"
-          fi
-
-      - name: Calculate pdf version
-        id: pdf_version
-        run: |
-          LAST_TAG=$(git tag -l 'pdf@*' --sort=-v:refname | head -n1 || echo "")
-          CURRENT_VERSION=$(node -p "require('./packages/pdf/package.json').version")
-
-          if [ -z "$LAST_TAG" ]; then
-            BASE_COMMIT="$(git rev-list --max-parents=0 HEAD)"
-          else
-            BASE_COMMIT="$LAST_TAG"
-          fi
-
-          COMMITS=$(git log "$BASE_COMMIT"..HEAD --pretty=format:"%H" -- packages/pdf/)
-          FEAT_COUNT=0; FIX_COUNT=0; BREAKING=0
-          for SHA in $COMMITS; do
-            SUBJECT=$(git log -1 --pretty=format:"%s" "$SHA")
-            BODY=$(git log -1 --pretty=format:"%b" "$SHA")
-            echo "$SUBJECT" | grep -qE "^feat(\([^)]+\))?[!:]" && FEAT_COUNT=$((FEAT_COUNT + 1))
-            echo "$SUBJECT" | grep -qE "^fix(\([^)]+\))?[!:]"  && FIX_COUNT=$((FIX_COUNT + 1))
-            echo "$BODY"    | grep -qE "^BREAKING[ -]CHANGE:"   && BREAKING=$((BREAKING + 1))
-            echo "$SUBJECT" | grep -qE "^[a-z]+(\([^)]+\))?!:"  && BREAKING=$((BREAKING + 1))
-          done
-
-          if [ "$FEAT_COUNT" -gt 0 ] || [ "$FIX_COUNT" -gt 0 ] || [ "$BREAKING" -gt 0 ]; then
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-            if [ "$BREAKING" -gt 0 ]; then
-              NEW_VERSION="$((MAJOR + 1)).0.0"
-            elif [ "$FEAT_COUNT" -gt 0 ]; then
-              NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
-            else
-              NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
-            fi
-            echo "published=true"       >> $GITHUB_OUTPUT
-            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-            echo "tag=pdf@$NEW_VERSION" >> $GITHUB_OUTPUT
-            echo "PDF: v$NEW_VERSION (feat=$FEAT_COUNT fix=$FIX_COUNT breaking=$BREAKING)"
-          else
-            echo "published=false" >> $GITHUB_OUTPUT
-            echo "PDF: no changes detected"
-          fi
-
-      - name: Create and push Git tags
-        if: steps.core_version.outputs.published == 'true' || steps.pdf_version.outputs.published == 'true'
-        run: |
-          push_tag() {
-            local TAG="$1"
-            if git rev-parse "$TAG" >/dev/null 2>&1; then
-              echo "Tag $TAG already exists, skipping"
-            else
-              git tag "$TAG"
-              git push origin "$TAG"
-              echo "Created tag $TAG"
-            fi
-          }
-
-          if [ "${{ steps.core_version.outputs.published }}" == "true" ]; then
-            push_tag "${{ steps.core_version.outputs.tag }}"
-          fi
-          if [ "${{ steps.pdf_version.outputs.published }}" == "true" ]; then
-            push_tag "${{ steps.pdf_version.outputs.tag }}"
-          fi
-
       - name: Build Documentation
         run: npm run docs:build
 
-      - name: Create GitHub Release (core)
-        if: steps.core_version.outputs.published == 'true'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.core_version.outputs.tag }}
-          name: "@arcasdk/core ${{ steps.core_version.outputs.version }}"
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create GitHub Release (pdf)
-        if: steps.pdf_version.outputs.published == 'true'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.pdf_version.outputs.tag }}
-          name: "@arcasdk/pdf ${{ steps.pdf_version.outputs.version }}"
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish Summary
+      - name: Summary
         run: |
-          echo "## 📦 Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## ✅ Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **Documentation Built**: Documentation updated" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **Code Built**: Packages built successfully" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Packages**: Built successfully" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Documentation**: Built successfully" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### @arcasdk/core" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.core_version.outputs.published }}" == "true" ]; then
-            echo "✅ **Version**: ${{ steps.core_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "ℹ️ No changes detected" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### @arcasdk/pdf" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.pdf_version.outputs.published }}" == "true" ]; then
-            echo "✅ **Version**: ${{ steps.pdf_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "ℹ️ No changes detected" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.core_version.outputs.published }}" == "true" ] || [ "${{ steps.pdf_version.outputs.published }}" == "true" ]; then
-            echo "🚀 **Next Step**: Run 'Publish to NPM' workflow manually" >> $GITHUB_STEP_SUMMARY
-          fi
-
-  publish-ready:
-    name: Ready for NPM Publishing
-    needs: release
-    if: needs.release.outputs.core_published == 'true' || needs.release.outputs.pdf_published == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Ready
-        run: |
-          echo "✅ Release is ready for publishing to NPM!"
-          echo ""
-          echo "👉 Next: Go to 'Actions' tab → '📦 Publish to NPM' → 'Run workflow'"
-          echo ""
-          echo "ℹ️ This is a manual step to prevent accidental publications"
+          echo "🚀 To publish, run '📦 Publish to NPM' workflow manually" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Split 'nx release --yes' into separate version/publish/tag steps
- npm-publish.yml now pushes only tags (not commits) to avoid branch protection rejection
- Remove tag creation and GitHub Release from release.yml to prevent conflicts with npm-publish.yml
- Move GitHub Release creation to npm-publish.yml using gh CLI
- Rename release.yml to 'CI & Documentation' (build + docs only)

 All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally before submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

